### PR TITLE
Add option to use "iptables -w" switch

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ type RootOptions struct {
 	OutboundPortsToIgnore []int
 	SimulateOnly          bool
 	NetNs                 string
+	UseWaitFlag           bool
 }
 
 func newRootOptions() *RootOptions {
@@ -29,6 +30,7 @@ func newRootOptions() *RootOptions {
 		OutboundPortsToIgnore: make([]int, 0),
 		SimulateOnly:          false,
 		NetNs:                 "",
+		UseWaitFlag:           true,
 	}
 }
 
@@ -58,6 +60,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.PersistentFlags().IntSliceVar(&options.OutboundPortsToIgnore, "outbound-ports-to-ignore", options.OutboundPortsToIgnore, "Outbound ports to ignore and not redirect to proxy. This has higher precedence than any other parameters.")
 	cmd.PersistentFlags().BoolVar(&options.SimulateOnly, "simulate", options.SimulateOnly, "Don't execute any command, just print what would be executed")
 	cmd.PersistentFlags().StringVar(&options.NetNs, "netns", options.NetNs, "Optional network namespace in which to run the iptables commands")
+	cmd.PersistentFlags().BoolVarP(&options.UseWaitFlag, "use-wait-flag", "w", options.UseWaitFlag, "Appends the \"-w\" flag to the iptables commands")
 
 	return cmd
 }
@@ -81,6 +84,7 @@ func BuildFirewallConfiguration(options *RootOptions) (*iptables.FirewallConfigu
 		OutboundPortsToIgnore:  options.OutboundPortsToIgnore,
 		SimulateOnly:           options.SimulateOnly,
 		NetNs:                  options.NetNs,
+		UseWaitFlag:            options.UseWaitFlag,
 	}
 
 	if len(options.PortsToRedirect) > 0 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ func newRootOptions() *RootOptions {
 		OutboundPortsToIgnore: make([]int, 0),
 		SimulateOnly:          false,
 		NetNs:                 "",
-		UseWaitFlag:           true,
+		UseWaitFlag:           false,
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -21,6 +21,7 @@ func TestBuildFirewallConfiguration(t *testing.T) {
 			ProxyOutgoingPort:      expectedOutgoingProxyPort,
 			ProxyUID:               expectedProxyUserID,
 			SimulateOnly:           false,
+			UseWaitFlag:            true,
 		}
 
 		options := newRootOptions()
@@ -34,7 +35,7 @@ func TestBuildFirewallConfiguration(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(config, expectedConfig) {
-			t.Fatalf("Expected config [%v] but got [%v]", expectedConfig, config)
+			t.Fatalf("Expected config \n[%+v]\n but got \n[%+v]", expectedConfig, config)
 		}
 	})
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -21,7 +21,7 @@ func TestBuildFirewallConfiguration(t *testing.T) {
 			ProxyOutgoingPort:      expectedOutgoingProxyPort,
 			ProxyUID:               expectedProxyUserID,
 			SimulateOnly:           false,
-			UseWaitFlag:            true,
+			UseWaitFlag:            false,
 		}
 
 		options := newRootOptions()


### PR DESCRIPTION
This relates to [linkerd2 #2970](https://github.com/linkerd/linkerd2/issues/2970).

The individual reporting the issue found this output in his logs:

`Another app is currently holding the xtables lock. Perhaps you want to use the -w option?
Aborting firewall configuration`

This pull request addresses that by adding a flag which will allow a user to specify the `iptables -w` switch.