### PR TITLE
Update Dockerfile to use buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         iptables \
         procps \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 COPY LICENSE /linkerd/LICENSE
 COPY --from=golang /out/linkerd2-proxy-init /usr/local/bin/proxy-init
 ENTRYPOINT ["/usr/local/bin/proxy-init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/linkerd2-proxy-init -mod=readonly -ldflags "-s -w" -v
 
 ## package runtime
-FROM --platform=$TARGETPLATFORM debian:buster-20190910-slim
+FROM --platform=$TARGETPLATFORM debian:buster-20200514-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         iptables \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/linkerd2-proxy-init -mod=readonly -ldflags "-s -w" -v
 
 ## package runtime
-FROM --platform=$TARGETPLATFORM debian:stretch-20190812-slim
+FROM --platform=$TARGETPLATFORM debian:buster-20190910-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         iptables \

--- a/integration_test/iptables/iptablestest-lab.yaml
+++ b/integration_test/iptables/iptablestest-lab.yaml
@@ -83,6 +83,12 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: false
           runAsUser: 0
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+      volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
 ---
 apiVersion: v1
 kind: Service
@@ -132,6 +138,12 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: false
           runAsUser: 0
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+      volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
 ---
 apiVersion: v1
 kind: Pod
@@ -188,3 +200,9 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: false
           runAsUser: 0
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+      volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock


### PR DESCRIPTION
Signed-off-by: Charles Pretzer <charles@buoyant.io>

This commit updates the Dockerfile to use the buster slim image `debian:buster-20190910-slim`