### PR TITLE
Remove chain jump rules as part of cleanup

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -66,29 +66,6 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 	}
 	endSection()
 
-	startSection("cleanup")
-	// cleanup rules before adding new ones in
-	_ = executeCommand(
-		firewallConfiguration,
-		makeJumpFromChainToAnotherForAllProtocols(
-			IptablesOutputChainName,
-			outputChainName,
-			"install-proxy-init-prerouting",
-			true))
-	_ = executeCommand(
-		firewallConfiguration,
-		makeJumpFromChainToAnotherForAllProtocols(
-			IptablesPreroutingChainName,
-			redirectChainName,
-			"install-proxy-init-prerouting",
-			true))
-
-	for _, chain := range []string{outputChainName, redirectChainName} {
-		_ = executeCommand(firewallConfiguration, makeFlushChain(chain))
-		_ = executeCommand(firewallConfiguration, makeDeleteChain(chain))
-	}
-	endSection()
-
 	commands := make([]*exec.Cmd, 0)
 
 	startSection("configuration")

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -204,11 +204,11 @@ func addRulesForInboundPortRedirect(firewallConfiguration FirewallConfiguration,
 	return commands
 }
 
-func addRulesForIgnoredPorts(portsToIgnore []int, chainName string, commands []*exec.Cmd) []*exec.Cmd {
-	for _, ignoredPort := range portsToIgnore {
-		fmt.Printf("Will ignore port %d on chain %s\n", ignoredPort, chainName)
+func addRulesForIgnoredPorts(portsToIgnore []string, chainName string, commands []*exec.Cmd) []*exec.Cmd {
+	for _, destinations := range makeMultiportDestinations(portsToIgnore) {
+		fmt.Printf("Will ignore port %d on chain %s\n", destinations, chainName)
 
-		commands = append(commands, makeIgnorePort(chainName, ignoredPort, fmt.Sprintf("ignore-port-%d", ignoredPort)))
+		commands = append(commands, makeIgnorePorts(chainName, destinations, fmt.Sprintf("ignore-port-%d", strings.Join(destinations, ","))))
 	}
 	return commands
 }

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -272,18 +272,6 @@ func makeCreateNewChain(name string, comment string) *exec.Cmd {
 		"--comment", formatComment(comment))
 }
 
-func makeFlushChain(name string) *exec.Cmd {
-	return exec.Command("iptables",
-		"-t", "nat",
-		"-F", name)
-}
-
-func makeDeleteChain(name string) *exec.Cmd {
-	return exec.Command("iptables",
-		"-t", "nat",
-		"-X", name)
-}
-
 func makeRedirectChainToPort(chainName string, portToRedirect int, comment string) *exec.Cmd {
 	return exec.Command("iptables",
 		"-t", "nat",

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -206,9 +206,9 @@ func addRulesForInboundPortRedirect(firewallConfiguration FirewallConfiguration,
 
 func addRulesForIgnoredPorts(portsToIgnore []string, chainName string, commands []*exec.Cmd) []*exec.Cmd {
 	for _, destinations := range makeMultiportDestinations(portsToIgnore) {
-		fmt.Printf("Will ignore port %d on chain %s\n", destinations, chainName)
+		fmt.Printf("Will ignore port %s on chain %s\n", destinations, chainName)
 
-		commands = append(commands, makeIgnorePorts(chainName, destinations, fmt.Sprintf("ignore-port-%d", strings.Join(destinations, ","))))
+		commands = append(commands, makeIgnorePorts(chainName, destinations, fmt.Sprintf("ignore-port-%s", strings.Join(destinations, ","))))
 	}
 	return commands
 }

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -27,11 +27,15 @@ const (
 
 	// IptablesMultiportLimit specifies the maximum number of port references per single iptables command.
 	IptablesMultiportLimit = 15
+	outputChainName        = "PROXY_INIT_OUTPUT"
+	redirectChainName      = "PROXY_INIT_REDIRECT"
 )
 
 var (
 	// ExecutionTraceID provides a unique identifier for this script's execution.
 	ExecutionTraceID = strconv.Itoa(int(time.Now().Unix()))
+
+	sectionDelimiter = strings.Repeat("-", 60)
 )
 
 // FirewallConfiguration specifies how to configure a pod's iptables.
@@ -53,32 +57,63 @@ type FirewallConfiguration struct {
 // https://github.com/istio/istio/blob/e83411e/pilot/docker/prepare_proxy.sh
 func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 
-	log.Printf("Tracing this script execution as [%s]\n", ExecutionTraceID)
+	fmt.Printf("Tracing this script execution as [%s]\n", ExecutionTraceID)
 
-	log.Println("State of iptables rules before run:")
-	err := executeCommand(firewallConfiguration, makeShowAllRules())
-	if err != nil {
-		log.Println("Aborting firewall configuration")
+	startSection("current state")
+	if err := executeCommand(firewallConfiguration, makeShowAllRules()); err != nil {
+		fmt.Println("Aborting firewall configuration")
 		return err
 	}
+	endSection()
+
+	startSection("cleanup")
+	// cleanup rules before adding new ones in
+	_ = executeCommand(
+		firewallConfiguration,
+		makeJumpFromChainToAnotherForAllProtocols(
+			IptablesOutputChainName,
+			outputChainName,
+			"install-proxy-init-prerouting",
+			true))
+	_ = executeCommand(
+		firewallConfiguration,
+		makeJumpFromChainToAnotherForAllProtocols(
+			IptablesPreroutingChainName,
+			redirectChainName,
+			"install-proxy-init-prerouting",
+			true))
+
+	for _, chain := range []string{outputChainName, redirectChainName} {
+		_ = executeCommand(firewallConfiguration, makeFlushChain(chain))
+		_ = executeCommand(firewallConfiguration, makeDeleteChain(chain))
+	}
+	endSection()
 
 	commands := make([]*exec.Cmd, 0)
+
+	startSection("configuration")
 
 	commands = addIncomingTrafficRules(commands, firewallConfiguration)
 
 	commands = addOutgoingTrafficRules(commands, firewallConfiguration)
 
-	commands = append(commands, makeShowAllRules())
+	endSection()
 
-	log.Println("Executing commands:")
+	startSection("adding rules")
 
 	for _, cmd := range commands {
-		err := executeCommand(firewallConfiguration, cmd)
-		if err != nil {
-			log.Println("Aborting firewall configuration")
+		if err := executeCommand(firewallConfiguration, cmd); err != nil {
+			fmt.Println("Aborting firewall configuration")
 			return err
 		}
 	}
+
+	endSection()
+
+	startSection("end state")
+	_ = executeCommand(firewallConfiguration, makeShowAllRules())
+	endSection()
+
 	return nil
 }
 
@@ -88,29 +123,25 @@ func formatComment(text string) string {
 	return fmt.Sprintf("proxy-init/%s/%s", text, ExecutionTraceID)
 }
 
+func startSection(text string) {
+	fmt.Printf("%s\n%s\n", text, sectionDelimiter)
+}
+
+func endSection() {
+	fmt.Printf("\n\n")
+}
+
 func addOutgoingTrafficRules(commands []*exec.Cmd, firewallConfiguration FirewallConfiguration) []*exec.Cmd {
-	outputChainName := "PROXY_INIT_OUTPUT"
-	redirectChainName := "PROXY_INIT_REDIRECT"
-	err := executeCommand(firewallConfiguration, makeFlushChain(outputChainName))
-	if err != nil {
-		log.Printf("An error occurred while FLUSHING the chain in addOutgoingTrafficRules. Startup will continue, but there may be additional errors\n [error]: %v", err)
-	}
-
-	err = executeCommand(firewallConfiguration, makeDeleteChain(outputChainName))
-	if err != nil {
-		log.Printf("An error occurred while DELETING the chain in addOutgoingTrafficRules. Startup will continue, but there may be additional errors\n [error]: %v", err)
-	}
-
 	commands = append(commands, makeCreateNewChain(outputChainName, "redirect-common-chain"))
 
 	// Ignore traffic from the proxy
 	if firewallConfiguration.ProxyUID > 0 {
-		log.Printf("Ignoring uid %d", firewallConfiguration.ProxyUID)
+		fmt.Printf("Ignoring uid %d\n", firewallConfiguration.ProxyUID)
 		// Redirect calls originating from the proxy destined for an app container e.g. app -> proxy(outbound) -> proxy(inbound) -> app
 		commands = append(commands, makeRedirectChainForOutgoingTraffic(outputChainName, redirectChainName, firewallConfiguration.ProxyUID, "redirect-non-loopback-local-traffic"))
 		commands = append(commands, makeIgnoreUserID(outputChainName, firewallConfiguration.ProxyUID, "ignore-proxy-user-id"))
 	} else {
-		log.Println("Not ignoring any uid")
+		fmt.Println("Not ignoring any uid")
 	}
 
 	// Ignore loopback
@@ -118,60 +149,66 @@ func addOutgoingTrafficRules(commands []*exec.Cmd, firewallConfiguration Firewal
 	// Ignore ports
 	commands = addRulesForIgnoredPorts(firewallConfiguration.OutboundPortsToIgnore, outputChainName, commands)
 
-	log.Printf("Redirecting all OUTPUT to %d", firewallConfiguration.ProxyOutgoingPort)
+	fmt.Printf("Redirecting all OUTPUT to %d\n", firewallConfiguration.ProxyOutgoingPort)
 	commands = append(commands, makeRedirectChainToPort(outputChainName, firewallConfiguration.ProxyOutgoingPort, "redirect-all-outgoing-to-proxy-port"))
 
 	//Redirect all remaining outbound traffic to the proxy.
-	commands = append(commands, makeJumpFromChainToAnotherForAllProtocols(IptablesOutputChainName, outputChainName, "install-proxy-init-output"))
+	commands = append(
+		commands,
+		makeJumpFromChainToAnotherForAllProtocols(
+			IptablesOutputChainName,
+			outputChainName,
+			"install-proxy-init-output",
+			false))
+
 	return commands
 }
 
 func addIncomingTrafficRules(commands []*exec.Cmd, firewallConfiguration FirewallConfiguration) []*exec.Cmd {
-	redirectChainName := "PROXY_INIT_REDIRECT"
-	err := executeCommand(firewallConfiguration, makeFlushChain(redirectChainName))
-	if err != nil {
-		log.Printf("An error occurred while FLUSHING the chain in addIncomingTrafficRules. Startup will continue, but there may be additional errors\n [error]: %v", err)
-	}
-
-	err = executeCommand(firewallConfiguration, makeDeleteChain(redirectChainName))
-	if err != nil {
-		log.Printf("An error occurred while DELETING the chain in addIncomingTrafficRules. Startup will continue, but there may be additional errors\n [error]: %v", err)
-	}
-
 	commands = append(commands, makeCreateNewChain(redirectChainName, "redirect-common-chain"))
 	commands = addRulesForIgnoredPorts(firewallConfiguration.InboundPortsToIgnore, redirectChainName, commands)
 	commands = addRulesForInboundPortRedirect(firewallConfiguration, redirectChainName, commands)
 
 	//Redirect all remaining inbound traffic to the proxy.
-	commands = append(commands, makeJumpFromChainToAnotherForAllProtocols(IptablesPreroutingChainName, redirectChainName, "install-proxy-init-prerouting"))
+	commands = append(
+		commands,
+		makeJumpFromChainToAnotherForAllProtocols(
+			IptablesPreroutingChainName,
+			redirectChainName,
+			"install-proxy-init-prerouting",
+			false))
 
 	return commands
 }
 
 func addRulesForInboundPortRedirect(firewallConfiguration FirewallConfiguration, chainName string, commands []*exec.Cmd) []*exec.Cmd {
 	if firewallConfiguration.Mode == RedirectAllMode {
-		log.Print("Will redirect all INPUT ports to proxy")
+		fmt.Println("Will redirect all INPUT ports to proxy")
 		//Create a new chain for redirecting inbound and outbound traffic to the proxy port.
 		commands = append(commands, makeRedirectChainToPort(chainName,
 			firewallConfiguration.ProxyInboundPort,
 			"redirect-all-incoming-to-proxy-port"))
 
 	} else if firewallConfiguration.Mode == RedirectListedMode {
-		log.Printf("Will redirect some INPUT ports to proxy: %v", firewallConfiguration.PortsToRedirectInbound)
+		fmt.Printf("Will redirect some INPUT ports to proxy: %v\n", firewallConfiguration.PortsToRedirectInbound)
 		for _, port := range firewallConfiguration.PortsToRedirectInbound {
-			commands = append(commands, makeRedirectChainToPortBasedOnDestinationPort(chainName,
-				port,
-				firewallConfiguration.ProxyInboundPort,
-				fmt.Sprintf("redirect-port-%d-to-proxy-port", port)))
+			commands = append(
+				commands,
+				makeRedirectChainToPortBasedOnDestinationPort(
+					chainName,
+					port,
+					firewallConfiguration.ProxyInboundPort,
+					fmt.Sprintf("redirect-port-%d-to-proxy-port", port)))
 		}
 	}
 	return commands
 }
 
-func addRulesForIgnoredPorts(portsToIgnore []string, chainName string, commands []*exec.Cmd) []*exec.Cmd {
-	for _, destinations := range makeMultiportDestinations(portsToIgnore) {
-		log.Printf("Will ignore port(s) %s on chain %s", destinations, chainName)
-		commands = append(commands, makeIgnorePorts(chainName, destinations, fmt.Sprintf("ignore-port-%s", strings.Join(destinations, ","))))
+func addRulesForIgnoredPorts(portsToIgnore []int, chainName string, commands []*exec.Cmd) []*exec.Cmd {
+	for _, ignoredPort := range portsToIgnore {
+		fmt.Printf("Will ignore port %d on chain %s\n", ignoredPort, chainName)
+
+		commands = append(commands, makeIgnorePort(chainName, ignoredPort, fmt.Sprintf("ignore-port-%d", ignoredPort)))
 	}
 	return commands
 }
@@ -207,34 +244,35 @@ func makeMultiportDestinations(portsToIgnore []string) [][]string {
 }
 
 func executeCommand(firewallConfiguration FirewallConfiguration, cmd *exec.Cmd) error {
-	originalCmd := strings.Trim(fmt.Sprintf("%v", cmd.Args), "[]")
-	log.Printf("> %s", originalCmd)
-
 	if firewallConfiguration.UseWaitFlag {
-		log.Print("Setting UseWaitFlag: iptables will wait for xtables to become available")
+		fmt.Println("Setting UseWaitFlag: iptables will wait for xtables to become available")
 		cmd.Args = append(cmd.Args, "-w")
 	}
 
-	if !firewallConfiguration.SimulateOnly {
-		// wrap up the cmd with nsenter if we were givin a netns
-		if len(firewallConfiguration.NetNs) > 0 {
-			netnsArg := fmt.Sprintf("--net=%s", firewallConfiguration.NetNs)
-			originalCmdAsArgs := strings.Split(originalCmd, " ")
-			nsenterArgs := []string{
-				netnsArg,
-			}
-			finalArgs := append(nsenterArgs, originalCmdAsArgs...)
-
-			log.Printf(">> nsenter %v", finalArgs)
-			cmd = exec.Command("nsenter", finalArgs...)
-		}
-
-		out, err := cmd.CombinedOutput()
-		log.Printf("< %s\n", string(out))
-		if err != nil {
-			return err
-		}
+	if firewallConfiguration.SimulateOnly {
+		return nil
 	}
+
+	// wrap up the cmd with nsenter if we were givin a netns
+	if len(firewallConfiguration.NetNs) > 0 {
+		cmd.Args = append([]string{
+			"nsenter",
+			"--net", firewallConfiguration.NetNs,
+		}, cmd.Args...)
+	}
+
+	fmt.Printf(":; %s\n", strings.Trim(fmt.Sprintf("%v", cmd.Args), "[]"))
+
+	out, err := cmd.CombinedOutput()
+
+	if len(out) > 0 {
+		fmt.Printf("%s\n", out)
+	}
+
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -314,10 +352,16 @@ func makeRedirectChainToPortBasedOnDestinationPort(chainName string, destination
 		"--comment", formatComment(comment))
 }
 
-func makeJumpFromChainToAnotherForAllProtocols(chainName string, targetChain string, comment string) *exec.Cmd {
+func makeJumpFromChainToAnotherForAllProtocols(
+	chainName string, targetChain string, comment string, delete bool) *exec.Cmd {
+	action := "-A"
+	if delete {
+		action = "-D"
+	}
+
 	return exec.Command("iptables",
 		"-t", "nat",
-		"-A", chainName,
+		action, chainName,
 		"-j", targetChain,
 		"-m", "comment",
 		"--comment", formatComment(comment))
@@ -337,7 +381,7 @@ func makeRedirectChainForOutgoingTraffic(chainName string, redirectChainName str
 }
 
 func makeShowAllRules() *exec.Cmd {
-	return exec.Command("iptables", "-t", "nat", "-vnL")
+	return exec.Command("iptables-save")
 }
 
 // asDestination formats the provided `PortRange` for output in commands.


### PR DESCRIPTION
This does a couple things:

- Adds delete for the jump rules to potentially address linkerd/linkerd2#3563
- Moves cleanup to run before everything instead of during configuration for personal sanity
- Simplifies the `nsenter` code a little so that the log output includes the commands run
- Improves readability of log output
- Uses `iptables-save` to get *all* rules instead of just the nat table
- Fixes a personal pet peeve of if/else statements.

Here's the new output:

```bash
Tracing this script execution as [1573775205]
current state
------------------------------------------------------------
:; iptables-save


cleanup
------------------------------------------------------------
:; iptables -t nat -D OUTPUT -j PROXY_INIT_OUTPUT -m comment --comment proxy-init/install-proxy-init-prerouting/1573775205
iptables v1.6.0: Couldn't load target `PROXY_INIT_OUTPUT':No such file or directory

Try `iptables -h' or 'iptables --help' for more information.

:; iptables -t nat -D PREROUTING -j PROXY_INIT_REDIRECT -m comment --comment proxy-init/install-proxy-init-prerouting/1573775205
iptables v1.6.0: Couldn't load target `PROXY_INIT_REDIRECT':No such file or directory

Try `iptables -h' or 'iptables --help' for more information.

:; iptables -t nat -F PROXY_INIT_OUTPUT
iptables: No chain/target/match by that name.

:; iptables -t nat -X PROXY_INIT_OUTPUT
iptables: No chain/target/match by that name.

:; iptables -t nat -F PROXY_INIT_REDIRECT
iptables: No chain/target/match by that name.

:; iptables -t nat -X PROXY_INIT_REDIRECT
iptables: No chain/target/match by that name.



configuration
------------------------------------------------------------
Will ignore port 4190 on chain PROXY_INIT_REDIRECT
Will ignore port 4191 on chain PROXY_INIT_REDIRECT
Will redirect all INPUT ports to proxy
Ignoring uid 2102
Will ignore port 443 on chain PROXY_INIT_OUTPUT
Redirecting all OUTPUT to 4140


adding rules
------------------------------------------------------------
:; iptables -t nat -N PROXY_INIT_REDIRECT -m comment --comment proxy-init/redirect-common-chain/1573775205
:; iptables -t nat -A PROXY_INIT_REDIRECT -p tcp --destination-port 4190 -j RETURN -m comment --comment proxy-init/ignore-port-4190/1573775205
:; iptables -t nat -A PROXY_INIT_REDIRECT -p tcp --destination-port 4191 -j RETURN -m comment --comment proxy-init/ignore-port-4191/1573775205
:; iptables -t nat -A PROXY_INIT_REDIRECT -p tcp -j REDIRECT --to-port 4143 -m comment --comment proxy-init/redirect-all-incoming-to-proxy-port/1573775205
:; iptables -t nat -A PREROUTING -j PROXY_INIT_REDIRECT -m comment --comment proxy-init/install-proxy-init-prerouting/1573775205
:; iptables -t nat -N PROXY_INIT_OUTPUT -m comment --comment proxy-init/redirect-common-chain/1573775205
:; iptables -t nat -A PROXY_INIT_OUTPUT -m owner --uid-owner 2102 -o lo ! -d 127.0.0.1/32 -j PROXY_INIT_REDIRECT -m comment --comment proxy-init/redirect-non-loopback-local-traffic/1573775205
:; iptables -t nat -A PROXY_INIT_OUTPUT -m owner --uid-owner 2102 -j RETURN -m comment --comment proxy-init/ignore-proxy-user-id/1573775205
:; iptables -t nat -A PROXY_INIT_OUTPUT -o lo -j RETURN -m comment --comment proxy-init/ignore-loopback/1573775205
:; iptables -t nat -A PROXY_INIT_OUTPUT -p tcp --destination-port 443 -j RETURN -m comment --comment proxy-init/ignore-port-443/1573775205
:; iptables -t nat -A PROXY_INIT_OUTPUT -p tcp -j REDIRECT --to-port 4140 -m comment --comment proxy-init/redirect-all-outgoing-to-proxy-port/1573775205
:; iptables -t nat -A OUTPUT -j PROXY_INIT_OUTPUT -m comment --comment proxy-init/install-proxy-init-output/1573775205


end state
------------------------------------------------------------
:; iptables-save
# Generated by iptables-save v1.6.0 on Thu Nov 14 23:46:45 2019
*nat
:PREROUTING ACCEPT [0:0]
:INPUT ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [0:0]
:PROXY_INIT_OUTPUT - [0:0]
:PROXY_INIT_REDIRECT - [0:0]
-A PREROUTING -m comment --comment "proxy-init/install-proxy-init-prerouting/1573775205" -j PROXY_INIT_REDIRECT
-A OUTPUT -m comment --comment "proxy-init/install-proxy-init-output/1573775205" -j PROXY_INIT_OUTPUT
-A PROXY_INIT_OUTPUT ! -d 127.0.0.1/32 -o lo -m owner --uid-owner 2102 -m comment --comment "proxy-init/redirect-non-loopback-local-traffic/1573775205" -j PROXY_INIT_REDIRECT
-A PROXY_INIT_OUTPUT -m owner --uid-owner 2102 -m comment --comment "proxy-init/ignore-proxy-user-id/1573775205" -j RETURN
-A PROXY_INIT_OUTPUT -o lo -m comment --comment "proxy-init/ignore-loopback/1573775205" -j RETURN
-A PROXY_INIT_OUTPUT -p tcp -m tcp --dport 443 -m comment --comment "proxy-init/ignore-port-443/1573775205" -j RETURN
-A PROXY_INIT_OUTPUT -p tcp -m comment --comment "proxy-init/redirect-all-outgoing-to-proxy-port/1573775205" -j REDIRECT --to-ports 4140
-A PROXY_INIT_REDIRECT -p tcp -m tcp --dport 4190 -m comment --comment "proxy-init/ignore-port-4190/1573775205" -j RETURN
-A PROXY_INIT_REDIRECT -p tcp -m tcp --dport 4191 -m comment --comment "proxy-init/ignore-port-4191/1573775205" -j RETURN
-A PROXY_INIT_REDIRECT -p tcp -m comment --comment "proxy-init/redirect-all-incoming-to-proxy-port/1573775205" -j REDIRECT --to-ports 4143
COMMIT
# Completed on Thu Nov 14 23:46:45 2019
```