### PR TITLE
Fix iptables comments ports format

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -157,7 +157,7 @@ func addRulesForInboundPortRedirect(firewallConfiguration FirewallConfiguration,
 func addRulesForIgnoredPorts(portsToIgnore []string, chainName string, commands []*exec.Cmd) []*exec.Cmd {
 	for _, destinations := range makeMultiportDestinations(portsToIgnore) {
 		log.Printf("Will ignore port(s) %s on chain %s", destinations, chainName)
-		commands = append(commands, makeIgnorePorts(chainName, destinations, fmt.Sprintf("ignore-port-%s", destinations)))
+		commands = append(commands, makeIgnorePorts(chainName, destinations, fmt.Sprintf("ignore-port-%s", strings.Join(destinations,","))))
 	}
 	return commands
 }


### PR DESCRIPTION
The fact that the comment was containing angle brackets caused the ip tables command to fail when used with netns in turn causing the linkerd cni plugin to not work properly. This fixes that problem. 

This fails with `2020/01/17 14:24:06 < Bad argument `4191]/1579271046'`

```
Command: 
./linkerd-cni --incoming-proxy-port "4143" --outgoing-proxy-port "4140" --proxy-uid "2102" --inbound-ports-to-ignore 4190,4191 --outbound-ports-to-ignore "443" --netns /proc/5850/ns/net
Resulting iptables cmd:
nsenter --net=/proc/5850/ns/net iptables -t nat -A PROXY_INIT_REDIRECT -p tcp --match multiport --dports 4190,4191 -j RETURN -m comment --comment proxy-init/ignore-port-[4190 4191]/1579271046
```

This does not: 

```
Command: 
./linkerd2-proxy-init-2 --incoming-proxy-port "4143" --outgoing-proxy-port "4140" --proxy-uid "2102" --inbound-ports-to-ignore 4190,4191 --outbound-ports-to-ignore "443"
Resulting iptables cmd:
iptables -t nat -A PROXY_INIT_REDIRECT -p tcp --match multiport --dports 4190,4191 -j RETURN -m comment --comment proxy-init/ignore-port-[4190 4191]/1579271046
```
Now they both work fine

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>