### PR TITLE
Fix go directive syntax in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/linkerd/linkerd2-proxy-init
 
-go 1.12.9
+go 1.12
 
 require github.com/spf13/cobra v0.0.5


### PR DESCRIPTION
The correct syntax for the `go` directive in `go.mod` is `go
Major.Minor`. Violating this generates an error in recent go versions.