### PR TITLE
Add close wait timeout flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:stretch-20190812-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         iptables \
+        procps \
     && rm -rf /var/lib/apt/lists/*
 COPY LICENSE /linkerd/LICENSE
 COPY --from=golang /out/linkerd2-proxy-init /usr/local/bin/proxy-init

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os/exec"
 
 	"github.com/spf13/cobra"
@@ -55,7 +56,7 @@ func NewRootCmd() *cobra.Command {
 					fmt.Sprintf("net.netfilter.nf_conntrack_tcp_timeout_close_wait=%d", options.TimeoutCloseWaitSecs),
 				)
 				out, err := sysctl.CombinedOutput()
-				fmt.Println(string(out))
+				log.Println(string(out))
 				if err != nil {
 					return err
 				}

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -157,7 +157,7 @@ func addRulesForInboundPortRedirect(firewallConfiguration FirewallConfiguration,
 func addRulesForIgnoredPorts(portsToIgnore []string, chainName string, commands []*exec.Cmd) []*exec.Cmd {
 	for _, destinations := range makeMultiportDestinations(portsToIgnore) {
 		log.Printf("Will ignore port(s) %s on chain %s", destinations, chainName)
-		commands = append(commands, makeIgnorePorts(chainName, destinations, fmt.Sprintf("ignore-port-%s", strings.Join(destinations,","))))
+		commands = append(commands, makeIgnorePorts(chainName, destinations, fmt.Sprintf("ignore-port-%s", strings.Join(destinations, ","))))
 	}
 	return commands
 }


### PR DESCRIPTION
We add a `timeout-close-wait-secs` flag to the proxy-init process that sets the `net.netfilter.nf_conntrack_tcp_timeout_close_wait`.  Note that this will fail if the container is not `privileged`.

Signed-off-by: Alex Leong <alex@buoyant.io>