### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code
-      # actions/checkout@v2
+      # actions/checkout@v2.0.0
       uses: actions/checkout@722adc6
     - name: Setup KinD
       # engineerd/setup-kind@v0.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+on:
+  push:
+    tags:
+    - "*"
+jobs:
+  buildx:
+    name: Build & Push Multi Arch Images
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Configure gcloud
+      uses: linkerd/linkerd2-action-gcloud@v1.0.2
+      with:
+        cloud_sdk_service_account_key: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
+        gcp_project: ${{ secrets.GCP_PROJECT }}
+        gcp_zone: ${{ secrets.GCP_ZONE }}
+    - name: Set up Docker Buildx
+      uses: crazy-max/ghaction-docker-buildx@v3
+    - name: Docker Buildx (build)
+      run: make images
+    - name: Docker Buildx (push)
+      run: make push
+    - name: Docker Check Manifest
+      run: make inspect-manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code
-      # actions/checkout@v2
+      # actions/checkout@v2.0.0
       uses: actions/checkout@722adc6
     - name: Configure gcloud
       # linkerd/linkerd2-action-gcloud@v1.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,18 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Configure gcloud
-      uses: linkerd/linkerd2-action-gcloud@v1.0.2
+      # linkerd/linkerd2-action-gcloud@v1.0.1
+      uses: linkerd/linkerd2-action-gcloud@308c4df
       with:
         cloud_sdk_service_account_key: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
         gcp_project: ${{ secrets.GCP_PROJECT }}
         gcp_zone: ${{ secrets.GCP_ZONE }}
     - name: Set up Docker Buildx
-      uses: crazy-max/ghaction-docker-buildx@v3
+      # crazy-max/ghaction-docker-buildx@v3.1.0
+      uses: crazy-max/ghaction-docker-buildx@373dafb
     - name: Docker Buildx (build)
       run: make images
     - name: Docker Buildx (push)

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -15,7 +15,7 @@ jobs:
       image: golang:1.13.4
     steps:
     - name: Checkout code
-      # actions/checkout@v2
+      # actions/checkout@v2.0.0
       uses: actions/checkout@722adc6
     - name: Lint
       # golangci/golangci-lint-action@v1.2.1
@@ -29,7 +29,7 @@ jobs:
       image: golang:1.13.4
     steps:
     - name: Checkout code
-      # actions/checkout@v2
+      # actions/checkout@v2.0.0
       uses: actions/checkout@722adc6
     - name: Format
       run: make fmt

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,7 +15,7 @@ jobs:
       image: golang:1.13.4
     steps:
     - name: Checkout code
-      # actions/checkout@v2
+      # actions/checkout@v2.0.0
       uses: actions/checkout@722adc6
     - name: Run unit tests
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -73,5 +73,6 @@ inspect-manifest: ## Check the resulting images supported architecture
 
 .PHONY: builder
 builder: ## Create the Buildx builder instance
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 	docker buildx create --name=multiarch-builder --driver=docker-container --platform="$(SUPPORTED_ARCHS)" --use
 	docker buildx inspect multiarch-builder --bootstrap

--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,8 @@ push: ## Push multi arch docker images to the registry
 inspect-manifest: ## Check the resulting images supported architecture
 	docker run --rm mplatform/mquery $(REPO):$(VERSION)
 	docker run --rm mplatform/mquery $(REPO):latest
+
+.PHONY: builder
+builder: ## Create the Buildx builder instance
+	docker buildx create --name=multiarch-builder --driver=docker-container --platform="$(SUPPORTED_ARCHS)" --use
+	docker buildx inspect multiarch-builder --bootstrap

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ REPO = $(DOCKER_REGISTRY)/proxy-init
 TESTER_REPO = buoyantio/iptables-tester
 VERSION ?= $(shell git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD)
 SUPPORTED_ARCHS = linux/amd64,linux/arm64,linux/arm/v7
+PUSH_IMAGE ?= false
 
 .DEFAULT_GOAL := help
 
@@ -56,19 +57,14 @@ kind-load: image tester-image ## Load the required image to KinD cluster
 images: ## Build multi arch docker images for the project
 	docker buildx build \
 		--platform $(SUPPORTED_ARCHS) \
-		--output "type=image,push=false" \
+		--output "type=image,push=$(PUSH_IMAGE)" \
 		--tag $(REPO):$(VERSION) \
 		--tag $(REPO):latest \
 		.
 
 .PHONY: push
-push: images ## Push multi arch docker images to the registry
-	docker buildx build \
-		--platform $(SUPPORTED_ARCHS) \
-		--output "type=image,push=true" \
-		--tag $(REPO):$(VERSION) \
-		--tag $(REPO):latest \
-		.
+push: ## Push multi arch docker images to the registry
+	PUSH_IMAGE=true make images
 
 .PHONY: inspect-manifest
 inspect-manifest: ## Check the resulting images supported architecture

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ make integration-test
 
 Please refer to [Docker Docs](https://docs.docker.com/buildx/working-with-buildx) to enable Buildx.
 
-Run `make builder` to create Buildx instance before starting to build the images.
-
 Run `make images` to start build the images.
 
 Run `make push` to push the images into registry.
@@ -34,3 +32,14 @@ Registry repo can be configured with environment variable:
 ```bash
 DOCKER_REGISTRY=<your registry> make push
 ```
+
+In some local environments like Ubuntu, where the default Buildx builder uses the `docker` driver, the `make images` command might fail with the following error:
+
+```bash
+$ make images
+multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
+Makefile:57: recipe for target 'images' failed
+make: *** [images] Error 1
+```
+
+To fix this, you can create a new Buildx builder instance by running `make builder`. This command will create a builder that uses the `docker-container` driver that can build multi-platform images. For more information, see the Buildx builder [documentation](https://docs.docker.com/buildx/working-with-buildx/#work-with-builder-instances).

--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ Then run the tests with:
 ```bash
 make integration-test
 ```
+
+# Build Multi-Architecture Docker Images with Buildx
+
+Please refer to https://docs.docker.com/buildx/working-with-buildx/ to enable Buildx.
+
+Run `make builder` to create Buildx instance before starting to build the images.
+
+Run `make images` to start build the images.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,15 @@ make integration-test
 
 # Build Multi-Architecture Docker Images with Buildx
 
-Please refer to https://docs.docker.com/buildx/working-with-buildx/ to enable Buildx.
+Please refer to [Docker Docs](https://docs.docker.com/buildx/working-with-buildx) to enable Buildx.
 
 Run `make builder` to create Buildx instance before starting to build the images.
 
 Run `make images` to start build the images.
+
+Run `make push` to push the images into registry.
+Registry repo can be configured with environment variable:
+
+```bash
+DOCKER_REGISTRY=<your registry> make push
+```


### PR DESCRIPTION
@cpretzer 

Tested manually in my local fork:
https://github.com/aliariff/linkerd2-proxy-init/pull/4/checks?check_run_id=800916941
Using the docker hub registry and my user & pass.
The resulting images are in https://hub.docker.com/r/etni35/proxy-init/tags
![image](https://user-images.githubusercontent.com/6806035/85457900-cdc73200-b5a0-11ea-9768-57e1623a4cc5.png)


This version only can be tested properly when we create a new release tag.
