### PR TITLE
Update the linkerd-init securityContext values

### DIFF
--- a/integration_test/iptables/iptablestest-lab.yaml
+++ b/integration_test/iptables/iptablestest-lab.yaml
@@ -74,10 +74,13 @@ spec:
         imagePullPolicy: Never
         args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           runAsUser: 0
 ---
@@ -120,10 +123,13 @@ spec:
         imagePullPolicy: Never
         args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-r", "9090", "-r", "9099"]
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           runAsUser: 0
 ---
@@ -173,9 +179,12 @@ spec:
         imagePullPolicy: Never
         args: ["-p", "8080",  "-o", "8080", "-u", "2102", "--inbound-ports-to-ignore", "6000-8000"]
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           runAsUser: 0


### PR DESCRIPTION
## What
The `proxy-init` integration tests are returning false positives.

## Why
The `securityContext` configuration integration tests for the proxy-init image has drifted from what is actually generated by `_proxy-init.tpl` in the [linkerd2 repo](https://github.com/linkerd/linkerd2/blob/master/charts/partials/templates/_proxy-init.tpl#L26).

As a result, the tests pass when they should fail after the changes to #3. 

## How
Update `iptablestest-lab.yaml` to include all the values under the `securityContext` key in the chart template.

Signed-off-by: Charles Pretzer <charles@buoyant.io>