### PR TITLE
fix linting rules

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -91,8 +91,15 @@ func formatComment(text string) string {
 func addOutgoingTrafficRules(commands []*exec.Cmd, firewallConfiguration FirewallConfiguration) []*exec.Cmd {
 	outputChainName := "PROXY_INIT_OUTPUT"
 	redirectChainName := "PROXY_INIT_REDIRECT"
-	executeCommand(firewallConfiguration, makeFlushChain(outputChainName))
-	executeCommand(firewallConfiguration, makeDeleteChain(outputChainName))
+	err := executeCommand(firewallConfiguration, makeFlushChain(outputChainName))
+	executeCommand(firewallConfiguration, makeDeleteChain(outputChainName))		if err != nil {
+		log.Printf("An error occurred while FLUSHING the chain in addOutgoingTrafficRules. Startup will continue, but there may be additional errors\n [error]: %v", err)
+	}
+
+	err = executeCommand(firewallConfiguration, makeDeleteChain(outputChainName))
+	if err != nil {
+		log.Printf("An error occurred while DELETING the chain in addOutgoingTrafficRules. Startup will continue, but there may be additional errors\n [error]: %v", err)
+	}
 
 	commands = append(commands, makeCreateNewChain(outputChainName, "redirect-common-chain"))
 
@@ -121,8 +128,15 @@ func addOutgoingTrafficRules(commands []*exec.Cmd, firewallConfiguration Firewal
 
 func addIncomingTrafficRules(commands []*exec.Cmd, firewallConfiguration FirewallConfiguration) []*exec.Cmd {
 	redirectChainName := "PROXY_INIT_REDIRECT"
-	executeCommand(firewallConfiguration, makeFlushChain(redirectChainName))
-	executeCommand(firewallConfiguration, makeDeleteChain(redirectChainName))
+	err := executeCommand(firewallConfiguration, makeFlushChain(redirectChainName))
+	executeCommand(firewallConfiguration, makeDeleteChain(redirectChainName))		if err != nil {
+		log.Printf("An error occurred while FLUSHING the chain in addIncomingTrafficRules. Startup will continue, but there may be additional errors\n [error]: %v", err)
+	}
+
+	err = executeCommand(firewallConfiguration, makeDeleteChain(redirectChainName))
+	if err != nil {
+		log.Printf("An error occurred while DELETING the chain in addIncomingTrafficRules. Startup will continue, but there may be additional errors\n [error]: %v", err)
+	}
 
 	commands = append(commands, makeCreateNewChain(redirectChainName, "redirect-common-chain"))
 	commands = addRulesForIgnoredPorts(firewallConfiguration.InboundPortsToIgnore, redirectChainName, commands)

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -92,7 +92,6 @@ func addOutgoingTrafficRules(commands []*exec.Cmd, firewallConfiguration Firewal
 	outputChainName := "PROXY_INIT_OUTPUT"
 	redirectChainName := "PROXY_INIT_REDIRECT"
 	err := executeCommand(firewallConfiguration, makeFlushChain(outputChainName))
-	executeCommand(firewallConfiguration, makeDeleteChain(outputChainName))
 	if err != nil {
 		log.Printf("An error occurred while FLUSHING the chain in addOutgoingTrafficRules. Startup will continue, but there may be additional errors\n [error]: %v", err)
 	}
@@ -130,7 +129,6 @@ func addOutgoingTrafficRules(commands []*exec.Cmd, firewallConfiguration Firewal
 func addIncomingTrafficRules(commands []*exec.Cmd, firewallConfiguration FirewallConfiguration) []*exec.Cmd {
 	redirectChainName := "PROXY_INIT_REDIRECT"
 	err := executeCommand(firewallConfiguration, makeFlushChain(redirectChainName))
-	executeCommand(firewallConfiguration, makeDeleteChain(redirectChainName))
 	if err != nil {
 		log.Printf("An error occurred while FLUSHING the chain in addIncomingTrafficRules. Startup will continue, but there may be additional errors\n [error]: %v", err)
 	}

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -92,7 +92,8 @@ func addOutgoingTrafficRules(commands []*exec.Cmd, firewallConfiguration Firewal
 	outputChainName := "PROXY_INIT_OUTPUT"
 	redirectChainName := "PROXY_INIT_REDIRECT"
 	err := executeCommand(firewallConfiguration, makeFlushChain(outputChainName))
-	executeCommand(firewallConfiguration, makeDeleteChain(outputChainName))		if err != nil {
+	executeCommand(firewallConfiguration, makeDeleteChain(outputChainName))
+	if err != nil {
 		log.Printf("An error occurred while FLUSHING the chain in addOutgoingTrafficRules. Startup will continue, but there may be additional errors\n [error]: %v", err)
 	}
 
@@ -129,7 +130,8 @@ func addOutgoingTrafficRules(commands []*exec.Cmd, firewallConfiguration Firewal
 func addIncomingTrafficRules(commands []*exec.Cmd, firewallConfiguration FirewallConfiguration) []*exec.Cmd {
 	redirectChainName := "PROXY_INIT_REDIRECT"
 	err := executeCommand(firewallConfiguration, makeFlushChain(redirectChainName))
-	executeCommand(firewallConfiguration, makeDeleteChain(redirectChainName))		if err != nil {
+	executeCommand(firewallConfiguration, makeDeleteChain(redirectChainName))
+	if err != nil {
 		log.Printf("An error occurred while FLUSHING the chain in addIncomingTrafficRules. Startup will continue, but there may be additional errors\n [error]: %v", err)
 	}
 


### PR DESCRIPTION
### What
There are linting errors because the calls to `executeCommand` don't handle the return values.

### How
Added checks for the `error` value that is returned and print a message if there is an error. The proxy init will still continue to run, so this change doesn't change the current logic.

### Why
The linting errors are holding up some other PRs, so I'm moving this change from #3 to its own PR, because there is more work to be done in #3 and I don't want to hold this change up.

Signed-off-by: Charles Pretzer <charles@buoyant.io>