### PR TITLE
temporarily disable push and inspect in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,19 +11,19 @@ jobs:
     - name: Checkout code
       # actions/checkout@v2.0.0
       uses: actions/checkout@722adc6
-    - name: Configure gcloud
+#    - name: Configure gcloud
       # linkerd/linkerd2-action-gcloud@v1.0.1
-      uses: linkerd/linkerd2-action-gcloud@308c4df
-      with:
-        cloud_sdk_service_account_key: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
-        gcp_project: ${{ secrets.GCP_PROJECT }}
-        gcp_zone: ${{ secrets.GCP_ZONE }}
+#      uses: linkerd/linkerd2-action-gcloud@308c4df
+#      with:
+#       cloud_sdk_service_account_key: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
+#       gcp_project: ${{ secrets.GCP_PROJECT }}
+#       gcp_zone: ${{ secrets.GCP_ZONE }}
     - name: Set up Docker Buildx
       # crazy-max/ghaction-docker-buildx@v3.1.0
       uses: crazy-max/ghaction-docker-buildx@373dafb
     - name: Docker Buildx (build)
       run: make images
-    - name: Docker Buildx (push)
-      run: make push
-    - name: Docker Check Manifest
-      run: make inspect-manifest
+#   - name: Docker Buildx (push)
+#      run: make push
+#    - name: Docker Check Manifest
+#      run: make inspect-manifest


### PR DESCRIPTION
## What
As part of the GSoC work, a release workflow was added that requires connectivity to gcr.io using credentials in order to push the images that are built. For now, we are focusing on the build portion of the project and not the release. This means that we'll need to manually push the images until this is re-enabled.

## Why
When a new tag is created, the release workflow runs and fails when it attempts to connect to gcr.io. This is currently blocking creation of new tags in this repo, so this PR disables that process and we'll revisit it later.

## How
The authorization, push, and inspect steps of the release.yaml workflow are commented out in this PR.

Signed-off-by: Charles Pretzer <charles@buoyant.io>