### PR TITLE
make: Support publishing custom images to private registries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 DOCKER_REGISTRY ?= ghcr.io/linkerd
 REPO = $(DOCKER_REGISTRY)/proxy-init
 TESTER_REPO = buoyantio/iptables-tester
+TAG ?= latest
 VERSION ?= $(shell git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD)
 SUPPORTED_ARCHS = linux/amd64,linux/arm64,linux/arm/v7
 PUSH_IMAGE ?= false
-
 .DEFAULT_GOAL := help
 
 .PHONY: help
@@ -42,7 +42,13 @@ integration-test: image ## Perform integration test
 ###############
 .PHONY: image
 image: ## Build docker image for the project
-	DOCKER_BUILDKIT=1 docker build -t $(REPO):latest .
+	DOCKER_BUILDKIT=1 docker build -t $(REPO):$(TAG) .
+
+.PHONY: docker-push
+docker-push: ## push to any docker registry
+	make image
+	docker push $(REPO):$(TAG)
+
 
 .PHONY: tester-image
 tester-image: ## Build docker image for the tester component

--- a/README.md
+++ b/README.md
@@ -13,11 +13,27 @@ Start by building and tagging the `proxy-init` image required for the test:
 eval $(minikube docker-env)
 make image
 ```
-
 Then run the tests with:
 
 ```bash
 make integration-test
+```
+# Build and push to custom repo
+Start by building and tagging the `proxy-init` image   
+For custom tagging set the TAG parameter. (default is latest)     
+To build an image 
+```bash
+make TAG=git-1234 image
+```
+For building and pushing to a private registry set the DOCKER_REGISTRY parameter
+```bash
+make DOCKER_REGISTRY=ghcr.io/my-private-registry  TAG=git-1234 docker-push
+```
+
+To make use of the custom init-proxy you can tell linkerd during install which image to use  
+Example: 
+```bash
+linkerd install --init-image=$DOCKER_REGISTRY:proxy-init  --init-image-version=$TAG |  kubectl apply -f - 
 ```
 
 # Build Multi-Architecture Docker Images with Buildx


### PR DESCRIPTION
To make it easier to build custom images and deploy from private registries  its nice to be able to push via makefile without having to use buildx. 
Remove the hardcoded latest tagging from the docker image to a configurable tag with value:latest set to default instead. 