### PR TITLE
Update base container images

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   kind_integration_tests:
     name: KinD integration tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
       # actions/checkout@v2.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   buildx:
     name: Build & Push Multi Arch Images
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
       # actions/checkout@v2.0.0

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -10,9 +10,9 @@ on:
 jobs:
   go_lint:
     name: Go lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
-      image: golang:1.13.4
+      image: golang:1.14.15
     steps:
     - name: Checkout code
       # actions/checkout@v2.0.0
@@ -24,9 +24,9 @@ jobs:
         version: v1.29
   go_format:
     name: Go format
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
-      image: golang:1.13.4
+      image: golang:1.14.15
     steps:
     - name: Checkout code
       # actions/checkout@v2.0.0

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,9 +10,9 @@ on:
 jobs:
   go_unit_tests:
     name: Go unit tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
-      image: golang:1.13.4
+      image: golang:1.14.15
     steps:
     - name: Checkout code
       # actions/checkout@v2.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM --platform=$BUILDPLATFORM golang:1.12.9 as golang
+FROM --platform=$BUILDPLATFORM golang:1.14.15 as golang
 WORKDIR /build
 
 # cache dependencies
@@ -13,11 +13,11 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/linkerd2-proxy-init -mod=readonly -ldflags "-s -w" -v
 
 ## package runtime
-FROM --platform=$TARGETPLATFORM debian:buster-20201117-slim
+FROM --platform=$TARGETPLATFORM debian:buster-20210208-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        iptables \
-        procps \
+    iptables \
+    procps \
     && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --set iptables /usr/sbin/iptables-legacy \
     && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy


### PR DESCRIPTION
linkerd/linkerd2#5655 tracks updating our base Go version to 1.14.15.
Additionally, there is a newer version of the base debian image that
fixes several CVEs in OS-level dependencies.

This change:

- Unifies the Go version across Docker and CI to be 1.14.15;
- Updates the GitHub Actions base image from ubuntu-18.04 to
  ubuntu-20.04; and
- Updates the runtime base image from debian:buster-20201117-slim to
  debian:buster-20210208-slim.