### PR TITLE
Use full SHAs in github actions

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - name: Checkout code
       # actions/checkout@v2.0.0
-      uses: actions/checkout@722adc6
+      uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
     - name: Setup KinD
       # engineerd/setup-kind@v0.5.0
-      uses: engineerd/setup-kind@aa272fe
+      uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0
       with:
         version: v0.8.1
     - name: Docker build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - name: Checkout code
       # actions/checkout@v2.0.0
-      uses: actions/checkout@722adc6
+      uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
     - name: Set up Docker Buildx
       # crazy-max/ghaction-docker-buildx@v3.1.0
-      uses: crazy-max/ghaction-docker-buildx@373dafb
+      uses: crazy-max/ghaction-docker-buildx@373dafb963e27afd52567f12584adb676f5fd647
     - name: Docker Buildx (build)
       run: make images
     - name: Docker Buildx (push)

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
     - name: Checkout code
       # actions/checkout@v2.0.0
-      uses: actions/checkout@722adc6
+      uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
     - name: Lint
       # golangci/golangci-lint-action@v2.3.0
-      uses: golangci/golangci-lint-action@e868220
+      uses: golangci/golangci-lint-action@e868220d9fd3b523f1a8fcfb69749e8c7521ba14
       with:
         version: v1.29
   go_format:
@@ -30,6 +30,6 @@ jobs:
     steps:
     - name: Checkout code
       # actions/checkout@v2.0.0
-      uses: actions/checkout@722adc6
+      uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
     - name: Format
       run: make fmt

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
     - name: Checkout code
       # actions/checkout@v2.0.0
-      uses: actions/checkout@722adc6
+      uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
     - name: Run unit tests
       run: make test


### PR DESCRIPTION
This is now required for github actions to run