### PR TITLE
Log to stdout instead of stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"log"
 	"os"
 
 	"github.com/linkerd/linkerd2-proxy-init/cmd"
 )
 
 func main() {
+	log.SetOutput(os.Stdout)
+
 	if err := cmd.NewRootCmd().Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
All  unstructured logs collected from stderr marked usually with error level in tools like fluentd or similar.
Every pod restart causes error spam in monitoring tools though it is a initialisation debug logs - and it is frustrating.