### PR TITLE
Switch base image from Debian to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,8 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/linkerd2-proxy-init -mod=readonly -ldflags "-s -w" -v
 
 ## package runtime
-FROM --platform=$TARGETPLATFORM debian:buster-20210208-slim
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    iptables \
-    procps \
-    && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --set iptables /usr/sbin/iptables-legacy \
-    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+FROM --platform=$TARGETPLATFORM alpine:20210212
+RUN apk add iptables
 COPY LICENSE /linkerd/LICENSE
 COPY --from=golang /out/linkerd2-proxy-init /usr/local/bin/proxy-init
 ENTRYPOINT ["/usr/local/bin/proxy-init"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER_REGISTRY ?= ghcr.io/linkerd
 CLUSTER_NAME ?= kind
 REPO = $(DOCKER_REGISTRY)/proxy-init
-TESTER_REPO = buoyantio/iptables-tester
+TESTER_REPO = $(DOCKER_REGISTRY)/iptables-tester
 VERSION ?= $(shell git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD)
 SUPPORTED_ARCHS = linux/amd64,linux/arm64,linux/arm/v7
 PUSH_IMAGE ?= false

--- a/integration_test/iptables/iptablestest-lab.yaml
+++ b/integration_test/iptables/iptablestest-lab.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
       containers:
       - name: webserver
-        image: buoyantio/iptables-tester:v1
+        image: ghcr.io/linkerd/iptables-tester:v1
         env:
          - name: PORT
            value: "8080"
@@ -17,7 +17,7 @@ spec:
         - name: http
           containerPort: 8080
       - name: other-container
-        image: buoyantio/iptables-tester:v1
+        image: ghcr.io/linkerd/iptables-tester:v1
         env:
          - name: PORT
            value: "9090"
@@ -46,7 +46,7 @@ metadata:
 spec:
       containers:
       - name: other-container
-        image: buoyantio/iptables-tester:v1
+        image: ghcr.io/linkerd/iptables-tester:v1
         env:
          - name: PORT
            value: "9090"
@@ -55,7 +55,7 @@ spec:
         - name: http
           containerPort: 9090
       - name: proxy-stub
-        image: buoyantio/iptables-tester:v1
+        image: ghcr.io/linkerd/iptables-tester:v1
         env:
          - name: PORT
            value: "8080"
@@ -110,7 +110,7 @@ metadata:
 spec:
       containers:
       - name: proxy-stub
-        image: buoyantio/iptables-tester:v1
+        image: ghcr.io/linkerd/iptables-tester:v1
         env:
          - name: PORT
            value: "8080"
@@ -154,7 +154,7 @@ metadata:
 spec:
       containers:
       - name: proxy-stub
-        image: buoyantio/iptables-tester:v1
+        image: ghcr.io/linkerd/iptables-tester:v1
         env:
          - name: PORT
            value: "8080"
@@ -168,7 +168,7 @@ spec:
           privileged: false
           runAsUser: 2102
       - name: other-container
-        image: buoyantio/iptables-tester:v1
+        image: ghcr.io/linkerd/iptables-tester:v1
         env:
          - name: PORT
            value: "9090"
@@ -177,7 +177,7 @@ spec:
         - name: http
           containerPort: 9090
       - name: blacklisted-container
-        image: buoyantio/iptables-tester:v1
+        image: ghcr.io/linkerd/iptables-tester:v1
         env:
          - name: PORT
            value: "7070"

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -38,7 +38,7 @@ kubectl delete  "jobs/$TESTER_JOB_NAME"
 # if env var not set then build the image
 if [[ -z "${SKIP_BUILD_TESTER_IMAGE}" ]]; then
   header 'Building the image used in tests...'
-  docker build . -f iptables/Dockerfile-tester --tag buoyantio/iptables-tester:v1
+  docker build . -f iptables/Dockerfile-tester --tag ghcr.io/linkerd/iptables-tester:v1
   sleep 10
 fi
 
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
       - name: tester
-        image: buoyantio/iptables-tester:v1
+        image: ghcr.io/linkerd/iptables-tester:v1
         env:
           - name: POD_REDIRECTS_ALL_PORTS_IP
             value: ${POD_REDIRECTS_ALL_PORTS_IP}


### PR DESCRIPTION
I couldn't get rid of the base image (in an attempt to get rid of
unrelated CVE warnings thrown by cluster image scanners) because of the
need of iptables and the shared libs it depends on, so the best I could
do was to switch to Alpine. Still, that reduces the image size in amd64
  from 77.3MB to 13MB.

I also changed the registry from docker hub to ghcr.io for the tester
images, because `k3d image import` was complaining (note these images
aren't pushed though).

Finally, it's no longer necessary to install `procps` (used to run
`sysctl`) as it already comes installed in Alpine.

This was tested successfully in the ARM host.

Partially addresses comment in linkerd/linkerd2#5198