### PR TITLE
Skip configuring firewall if rules exists

### DIFF
--- a/integration_test/iptables/iptablestest-lab.yaml
+++ b/integration_test/iptables/iptablestest-lab.yaml
@@ -6,25 +6,25 @@ metadata:
   labels:
     app: pod-with-no-rules
 spec:
-      containers:
-      - name: webserver
-        image: ghcr.io/linkerd/iptables-tester:v1
-        env:
-         - name: PORT
-           value: "8080"
-        command: ["go", "run", "/go/test_service/test_service.go"]
-        ports:
-        - name: http
-          containerPort: 8080
-      - name: other-container
-        image: ghcr.io/linkerd/iptables-tester:v1
-        env:
-         - name: PORT
-           value: "9090"
-        command: ["go", "run", "/go/test_service/test_service.go"]
-        ports:
-        - name: http
-          containerPort: 9090
+  containers:
+  - name: webserver
+    image: ghcr.io/linkerd/iptables-tester:v1
+    env:
+    - name: PORT
+      value: "8080"
+    command: ["go", "run", "/go/test_service/test_service.go"]
+    ports:
+    - name: http
+      containerPort: 8080
+  - name: other-container
+    image: ghcr.io/linkerd/iptables-tester:v1
+    env:
+    - name: PORT
+      value: "9090"
+    command: ["go", "run", "/go/test_service/test_service.go"]
+    ports:
+    - name: http
+      containerPort: 9090
 ---
 apiVersion: v1
 kind: Service
@@ -44,63 +44,66 @@ metadata:
   labels:
     app: pod-with-existing-rules
 spec:
-      containers:
-      - name: webserver
-        image: buoyantio/iptables-tester:v1
-        env:
-         - name: PORT
-           value: "8080"
-        command: ["go", "run", "/go/test_service/test_service.go"]
-        ports:
-        - name: http
-          containerPort: 8080
-      - name: other-container
-        image: buoyantio/iptables-tester:v1
-        env:
-         - name: PORT
-           value: "9090"
-        command: ["go", "run", "/go/test_service/test_service.go"]
-        ports:
-        - name: http
-          containerPort: 9090
-      initContainers:
-      - name: iptables-test
-        image: ghcr.io/linkerd/proxy-init:latest
-        imagePullPolicy: Never
-        args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add:
-            - NET_ADMIN
-            - NET_RAW
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: false
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /run
-          name: linkerd-proxy-init-xtables-lock
-      - name: linkerd-init
-        image: ghcr.io/linkerd/proxy-init:latest
-        imagePullPolicy: Never
-        args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add:
-            - NET_ADMIN
-            - NET_RAW
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: false
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /run
-          name: linkerd-proxy-init-xtables-lock
-      volumes:
-      - emptyDir: {}
-        name: linkerd-proxy-init-xtables-lock
+  containers:
+  - name: webserver
+    image: ghcr.io/linkerd/iptables-tester:v1
+    env:
+    - name: PORT
+      value: "8080"
+    command: ["go", "run", "/go/test_service/test_service.go"]
+    ports:
+    - name: http
+      containerPort: 8080
+  - name: other-container
+    image: ghcr.io/linkerd/iptables-tester:v1
+    env:
+    - name: PORT
+      value: "9090"
+    command: ["go", "run", "/go/test_service/test_service.go"]
+    ports:
+    - name: http
+      containerPort: 9090
+  initContainers:
+  # The iptables-test init container is used to test what happens when
+  # iptable rules are run more than once. The linkerd-init container
+  # should log "Found existing firewall configuration..."
+  - name: iptables-test
+    image: ghcr.io/linkerd/proxy-init:latest
+    imagePullPolicy: Never
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: false
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /run
+      name: linkerd-proxy-init-xtables-lock
+  - name: linkerd-init
+    image: ghcr.io/linkerd/proxy-init:latest
+    imagePullPolicy: Never
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: false
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /run
+      name: linkerd-proxy-init-xtables-lock
+  volumes:
+  - emptyDir: {}
+    name: linkerd-proxy-init-xtables-lock
 ---
 apiVersion: v1
 kind: Pod
@@ -109,51 +112,51 @@ metadata:
   labels:
     app: pod-redirects-all-ports
 spec:
-      containers:
-      - name: other-container
-        image: ghcr.io/linkerd/iptables-tester:v1
-        env:
-         - name: PORT
-           value: "9090"
-        command: ["go", "run", "/go/test_service/test_service.go"]
-        ports:
-        - name: http
-          containerPort: 9090
-      - name: proxy-stub
-        image: ghcr.io/linkerd/iptables-tester:v1
-        env:
-         - name: PORT
-           value: "8080"
-         - name: AM_I_THE_PROXY
-           value: "yes"
-        command: ["go", "run", "/go/test_service/test_service.go"]
-        securityContext:
-          privileged: false
-          runAsUser: 2102
-        ports:
-        - name: http
-          containerPort: 8080
-      initContainers:
-      - name: linkerd-init
-        image: ghcr.io/linkerd/proxy-init:latest
-        imagePullPolicy: Never
-        args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add:
-            - NET_ADMIN
-            - NET_RAW
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: false
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /run
-          name: linkerd-proxy-init-xtables-lock
-      volumes:
-      - emptyDir: {}
-        name: linkerd-proxy-init-xtables-lock
+  containers:
+  - name: other-container
+    image: ghcr.io/linkerd/iptables-tester:v1
+    env:
+    - name: PORT
+      value: "9090"
+    command: ["go", "run", "/go/test_service/test_service.go"]
+    ports:
+    - name: http
+      containerPort: 9090
+  - name: proxy-stub
+    image: ghcr.io/linkerd/iptables-tester:v1
+    env:
+    - name: PORT
+      value: "8080"
+    - name: AM_I_THE_PROXY
+      value: "yes"
+    command: ["go", "run", "/go/test_service/test_service.go"]
+    securityContext:
+      privileged: false
+      runAsUser: 2102
+    ports:
+    - name: http
+      containerPort: 8080
+  initContainers:
+  - name: linkerd-init
+    image: ghcr.io/linkerd/proxy-init:latest
+    imagePullPolicy: Never
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: false
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /run
+      name: linkerd-proxy-init-xtables-lock
+  volumes:
+  - emptyDir: {}
+    name: linkerd-proxy-init-xtables-lock
 ---
 apiVersion: v1
 kind: Service
@@ -173,42 +176,42 @@ metadata:
   labels:
     app: pod-redirects-whitelisted
 spec:
-      containers:
-      - name: proxy-stub
-        image: ghcr.io/linkerd/iptables-tester:v1
-        env:
-         - name: PORT
-           value: "8080"
-         - name: AM_I_THE_PROXY
-           value: "yes"
-        command: ["go", "run", "/go/test_service/test_service.go"]
-        ports:
-        - name: http
-          containerPort: 8080
-        securityContext:
-          privileged: false
-          runAsUser: 2102
-      initContainers:
-      - name: linkerd-init
-        image: ghcr.io/linkerd/proxy-init:latest
-        imagePullPolicy: Never
-        args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-r", "9090", "-r", "9099"]
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add:
-            - NET_ADMIN
-            - NET_RAW
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: false
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /run
-          name: linkerd-proxy-init-xtables-lock
-      volumes:
-      - emptyDir: {}
-        name: linkerd-proxy-init-xtables-lock
+  containers:
+  - name: proxy-stub
+    image: ghcr.io/linkerd/iptables-tester:v1
+    env:
+    - name: PORT
+      value: "8080"
+    - name: AM_I_THE_PROXY
+      value: "yes"
+    command: ["go", "run", "/go/test_service/test_service.go"]
+    ports:
+    - name: http
+      containerPort: 8080
+    securityContext:
+      privileged: false
+      runAsUser: 2102
+  initContainers:
+  - name: linkerd-init
+    image: ghcr.io/linkerd/proxy-init:latest
+    imagePullPolicy: Never
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-r", "9090", "-r", "9099"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: false
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /run
+      name: linkerd-proxy-init-xtables-lock
+  volumes:
+  - emptyDir: {}
+    name: linkerd-proxy-init-xtables-lock
 ---
 apiVersion: v1
 kind: Pod
@@ -217,57 +220,57 @@ metadata:
   labels:
     app: pod-doesnt-redirect-blacklisted
 spec:
-      containers:
-      - name: proxy-stub
-        image: ghcr.io/linkerd/iptables-tester:v1
-        env:
-         - name: PORT
-           value: "8080"
-         - name: AM_I_THE_PROXY
-           value: "yes"
-        command: ["go", "run", "/go/test_service/test_service.go"]
-        ports:
-        - name: http
-          containerPort: 8080
-        securityContext:
-          privileged: false
-          runAsUser: 2102
-      - name: other-container
-        image: ghcr.io/linkerd/iptables-tester:v1
-        env:
-         - name: PORT
-           value: "9090"
-        command: ["go", "run", "/go/test_service/test_service.go"]
-        ports:
-        - name: http
-          containerPort: 9090
-      - name: blacklisted-container
-        image: ghcr.io/linkerd/iptables-tester:v1
-        env:
-         - name: PORT
-           value: "7070"
-        command: ["go", "run", "/go/test_service/test_service.go"]
-        ports:
-        - name: http
-          containerPort: 7070
-      initContainers:
-      - name: linkerd-init
-        image: ghcr.io/linkerd/proxy-init:latest
-        imagePullPolicy: Never
-        args: ["-p", "8080",  "-o", "8080", "-u", "2102", "--inbound-ports-to-ignore", "6000-8000"]
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add:
-            - NET_ADMIN
-            - NET_RAW
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: false
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /run
-          name: linkerd-proxy-init-xtables-lock
-      volumes:
-      - emptyDir: {}
-        name: linkerd-proxy-init-xtables-lock
+  containers:
+  - name: proxy-stub
+    image: ghcr.io/linkerd/iptables-tester:v1
+    env:
+    - name: PORT
+      value: "8080"
+    - name: AM_I_THE_PROXY
+      value: "yes"
+    command: ["go", "run", "/go/test_service/test_service.go"]
+    ports:
+    - name: http
+      containerPort: 8080
+    securityContext:
+      privileged: false
+      runAsUser: 2102
+  - name: other-container
+    image: ghcr.io/linkerd/iptables-tester:v1
+    env:
+    - name: PORT
+      value: "9090"
+    command: ["go", "run", "/go/test_service/test_service.go"]
+    ports:
+    - name: http
+      containerPort: 9090
+  - name: blacklisted-container
+    image: ghcr.io/linkerd/iptables-tester:v1
+    env:
+    - name: PORT
+      value: "7070"
+    command: ["go", "run", "/go/test_service/test_service.go"]
+    ports:
+    - name: http
+      containerPort: 7070
+  initContainers:
+  - name: linkerd-init
+    image: ghcr.io/linkerd/proxy-init:latest
+    imagePullPolicy: Never
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "--inbound-ports-to-ignore", "6000-8000"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: false
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /run
+      name: linkerd-proxy-init-xtables-lock
+  volumes:
+  - emptyDir: {}
+    name: linkerd-proxy-init-xtables-lock

--- a/integration_test/iptables/iptablestest-lab.yaml
+++ b/integration_test/iptables/iptablestest-lab.yaml
@@ -40,6 +40,71 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  name: pod-with-existing-rules
+  labels:
+    app: pod-with-existing-rules
+spec:
+      containers:
+      - name: webserver
+        image: buoyantio/iptables-tester:v1
+        env:
+         - name: PORT
+           value: "8080"
+        command: ["go", "run", "/go/test_service/test_service.go"]
+        ports:
+        - name: http
+          containerPort: 8080
+      - name: other-container
+        image: buoyantio/iptables-tester:v1
+        env:
+         - name: PORT
+           value: "9090"
+        command: ["go", "run", "/go/test_service/test_service.go"]
+        ports:
+        - name: http
+          containerPort: 9090
+      initContainers:
+      - name: iptables-test
+        image: ghcr.io/linkerd/proxy-init:latest
+        imagePullPolicy: Never
+        args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: false
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+      - name: linkerd-init
+        image: ghcr.io/linkerd/proxy-init:latest
+        imagePullPolicy: Never
+        args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: false
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+      volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
+---
+apiVersion: v1
+kind: Pod
+metadata:
   name: pod-redirects-all-ports
   labels:
     app: pod-redirects-all-ports

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -48,6 +48,9 @@ kubectl create -f "$LAB_YAML_FILE"
 POD_WITH_NO_RULES_IP=$(get_ip_for_pod 'pod-with-no-rules')
 log "POD_WITH_NO_RULES_IP=${POD_WITH_NO_RULES_IP}"
 
+POD_WITH_EXISTING_RULES_IP=$(get_ip_for_pod 'pod-with-existing-rules')
+log "POD_WITH_EXISTING_RULES_IP=${POD_WITH_EXISTING_RULES_IP}"
+
 POD_REDIRECTS_ALL_PORTS_IP=$(get_ip_for_pod 'pod-redirects-all-ports')
 log "POD_REDIRECTS_ALL_PORTS_IP=${POD_REDIRECTS_ALL_PORTS_IP}"
 
@@ -74,6 +77,8 @@ spec:
         env:
           - name: POD_REDIRECTS_ALL_PORTS_IP
             value: ${POD_REDIRECTS_ALL_PORTS_IP}
+          - name: POD_WITH_EXISTING_RULES_IP
+            value: ${POD_WITH_EXISTING_RULES_IP}
           - name: POD_WITH_NO_RULES_IP
             value: ${POD_WITH_NO_RULES_IP}
           - name: POD_REDIRECTS_WHITELISTED_IP

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -38,7 +38,7 @@ var (
 	// ExecutionTraceID provides a unique identifier for this script's execution.
 	ExecutionTraceID = strconv.Itoa(int(time.Now().Unix()))
 
-	chainRegex       = regexp.MustCompile(`-A (PROXY_INIT_OUTPUT|PROXY_INIT_REDIRECT) -m.*`)
+	chainRegex       = regexp.MustCompile(`-A (PROXY_INIT_OUTPUT|PROXY_INIT_REDIRECT).*`)
 	sectionDelimiter = strings.Repeat("-", 60)
 )
 
@@ -75,7 +75,7 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 
 	startSection("configuration")
 
-	matches := chainRegex.FindAllString(b.String(), -1)
+	matches := chainRegex.FindAllString(b.String(), 1)
 	if len(matches) > 0 {
 		log.Println("Found existing firewall configuration; Skipping")
 		return nil


### PR DESCRIPTION
This change fixes an issue where the `proxy-init` will fail if
`PROXY_INIT_*` chains already exist in the pod's iptables. This then
causes the pod to never start because proxy-init never finishes running
with a non-zero exit code.

In this change, we capture the output of the `iptables-save` command and
then check to see if the output contains the `PROXY_INIT_*` chains. If
they do, exist and log a warning stating that the chains already
exist.

Fixes #5786

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>