### PR TITLE
Drop rule to redirect outgoing traffic from app to itself

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup KinD
       uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0
       with:
-        version: v0.8.1
+        version: v0.11.1
     - name: Docker build
       run: |
         make image


### PR DESCRIPTION
## What

In order to restrict the proxy from forwarding to addresses not in [`LINKERD2_PROXY_INBOUND_IPS` (PR#1161)](https://github.com/linkerd/linkerd2-proxy/pull/1161), the proxy will have to forward to the original address rather than to the target port bound on localhost. 

The outgoing traffic redirect rule (`"redirect-non-loopback-local-traffic"`) redirects traffic that originates from the proxy's outbound side back to the inbound port when the application calls itself. This is done because a packet sent to the same address is routed through the loopback interface by the kernel -- this means that the packet will not be going through the `PREROUTING` chain (it will not be going through the `nat` table at all); if an app sends a request to itself, the outbound side will encrypt and upgrade to H2 so it needs to be routed back to the inbound side, otherwise the application will not know how to deal with the request.

Since the proxy will now forward on the original destination, it will be caught by this rule effectively forcing any packets generated from the inbound stack to be picked up on the inbound port again (it will just loop). The rule itself targets any packet generated by the proxy whose destination address _is not loopback_ -- removing this rule will allow the proxy to function normally again.

The downside to removing this rule is that the edge case of an application calling itself is broken, meaning packets from outbound will go straight back to the application process (who will not know how to deal with it). To get around this, we will [have to skip TLS and h2 upgrades](https://github.com/linkerd/linkerd2-proxy/pull/1219) when the destination is also an inbound ip.  

Signed-off-by: Matei David <matei@buoyant.io>