### PR TITLE
Adds log-format for linkerd-proxy-init (#6881)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,10 +6,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/spf13/cobra"
-
 	"github.com/linkerd/linkerd2-proxy-init/iptables"
 	"github.com/linkerd/linkerd2-proxy-init/ports"
+	"github.com/spf13/cobra"
 )
 
 // RootOptions provides the information that will be used to build a firewall configuration.
@@ -62,10 +61,10 @@ func NewRootCmd() *cobra.Command {
 				)
 				out, err := sysctl.CombinedOutput()
 				if err != nil {
-					log.Errorln(string(out))
+					log.Error(string(out))
 					return err
 				} else {
-					log.Println(string(out))
+					log.Info(string(out))
 				}
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/linkerd/linkerd2-proxy-init
 
 go 1.16
 
-require github.com/spf13/cobra v0.0.7
+require (
+	github.com/sirupsen/logrus v1.2.0 // indirect
+	github.com/spf13/cobra v0.0.7
+)

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -69,6 +70,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -91,6 +93,7 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -107,6 +110,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/linkerd/linkerd2-proxy-init/ports"
 )
@@ -66,7 +67,7 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 	startSection("current state")
 	b := bytes.Buffer{}
 	if err := executeCommand(firewallConfiguration, makeShowAllRules(), &b); err != nil {
-		log.Println("Aborting firewall configuration")
+		log.Error("Aborting firewall configuration")
 		return err
 	}
 	endSection()
@@ -91,7 +92,7 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 
 	for _, cmd := range commands {
 		if err := executeCommand(firewallConfiguration, cmd, nil); err != nil {
-			log.Println("Aborting firewall configuration")
+			log.Error("Aborting firewall configuration")
 			return err
 		}
 	}

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -64,7 +64,7 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 
 	log.Debugf("Tracing this script execution as [%s]", ExecutionTraceID)
 
-	startSection("current state")
+	log.Debugln("current state")
 	b := bytes.Buffer{}
 	if err := executeCommand(firewallConfiguration, makeShowAllRules(), &b); err != nil {
 		log.Error("Aborting firewall configuration")
@@ -73,7 +73,7 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 
 	commands := make([]*exec.Cmd, 0)
 
-	startSection("configuration")
+	log.Debugln("configuration")
 
 	matches := chainRegex.FindAllString(b.String(), 1)
 	if len(matches) > 0 {
@@ -85,7 +85,7 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 
 	commands = addOutgoingTrafficRules(commands, firewallConfiguration)
 
-	startSection("adding rules")
+	log.Debugln("adding rules")
 
 	for _, cmd := range commands {
 		if err := executeCommand(firewallConfiguration, cmd, nil); err != nil {
@@ -94,7 +94,7 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 		}
 	}
 
-	startSection("end state")
+	log.Debugln("end state")
 	_ = executeCommand(firewallConfiguration, makeShowAllRules(), nil)
 
 	return nil
@@ -104,13 +104,6 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 // This helps debug when iptables has some stale rules from previous runs, something that can happen frequently on minikube.
 func formatComment(text string) string {
 	return fmt.Sprintf("proxy-init/%s/%s", text, ExecutionTraceID)
-}
-
-func startSection(text string) {
-	log.Debugf("%s", text)
-}
-
-func endSection() {
 }
 
 func addOutgoingTrafficRules(commands []*exec.Cmd, firewallConfiguration FirewallConfiguration) []*exec.Cmd {

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -116,7 +116,7 @@ func addOutgoingTrafficRules(commands []*exec.Cmd, firewallConfiguration Firewal
 	// Ignore ports
 	commands = addRulesForIgnoredPorts(firewallConfiguration.OutboundPortsToIgnore, outputChainName, commands)
 
-	log.Printf("Redirecting all OUTPUT to %d", firewallConfiguration.ProxyOutgoingPort)
+	log.Infof("Redirecting all OUTPUT to %d", firewallConfiguration.ProxyOutgoingPort)
 	commands = append(commands, makeRedirectChainToPort(outputChainName, firewallConfiguration.ProxyOutgoingPort, "redirect-all-outgoing-to-proxy-port"))
 
 	//Redirect all remaining outbound traffic to the proxy.

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -39,8 +39,7 @@ var (
 	// ExecutionTraceID provides a unique identifier for this script's execution.
 	ExecutionTraceID = strconv.Itoa(int(time.Now().Unix()))
 
-	chainRegex       = regexp.MustCompile(`-A (PROXY_INIT_OUTPUT|PROXY_INIT_REDIRECT).*`)
-	sectionDelimiter = strings.Repeat("-", 60)
+	chainRegex = regexp.MustCompile(`-A (PROXY_INIT_OUTPUT|PROXY_INIT_REDIRECT).*`)
 )
 
 // FirewallConfiguration specifies how to configure a pod's iptables.

--- a/main.go
+++ b/main.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"log"
 	"os"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/linkerd/linkerd2-proxy-init/cmd"
 )


### PR DESCRIPTION
Linkerd-proxy-init currently did not support options to implement log formating, as opposed to other linkerd components.

This commit implements logging-format flag, to allow configure it to be a json or a plain output.

The logic applied tries to reflect the same one applied to linkerd control plane components.

This implementation changes the default logging behavior of proxy-init

Screenshot of behavior with plain format:
![image](https://user-images.githubusercontent.com/17139678/134529959-3f82a8b4-876f-488a-8b54-a3a7e403f702.png)

Screenshot of behavior with json format:
![image](https://user-images.githubusercontent.com/17139678/134529793-14e0abf0-6f79-4325-b35d-9394ae88797d.png)


Signed-off-by: Gustavo Carvalho <gusfcarvalho@gmail.com>