### PR TITLE
Linkerd without CNI as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/linkerd2-proxy-
 
 ## package runtime
 FROM --platform=$TARGETPLATFORM alpine:20210212
-RUN apk add iptables
+RUN apk add iptables libcap
+RUN touch /run/xtables.lock && chmod 0666 /run/xtables.lock
+RUN setcap cap_net_raw,cap_net_admin+eip /sbin/xtables-legacy-multi
 COPY LICENSE /linkerd/LICENSE
 COPY --from=golang /out/linkerd2-proxy-init /usr/local/bin/proxy-init
+RUN setcap cap_net_raw,cap_net_admin+eip /usr/local/bin/proxy-init
 ENTRYPOINT ["/usr/local/bin/proxy-init"]
+
+USER 65534

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -336,7 +336,7 @@ func makeJumpFromChainToAnotherForAllProtocols(
 }
 
 func makeShowAllRules() *exec.Cmd {
-	return exec.Command("iptables-save")
+	return exec.Command("iptables-save", "-t", "nat")
 }
 
 // asDestination formats the provided `PortRange` for output in commands.

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -56,11 +56,10 @@ type FirewallConfiguration struct {
 	UseWaitFlag            bool
 }
 
-//ConfigureFirewall configures a pod's internal iptables to redirect all desired traffic through the proxy, allowing for
+// ConfigureFirewall configures a pod's internal iptables to redirect all desired traffic through the proxy, allowing for
 // the pod to join the service mesh. A lot of this logic was based on
 // https://github.com/istio/istio/blob/e83411e/pilot/docker/prepare_proxy.sh
 func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
-
 	log.Debugf("Tracing this script execution as [%s]", ExecutionTraceID)
 
 	b := bytes.Buffer{}
@@ -94,7 +93,7 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 	return nil
 }
 
-//formatComment is used to format iptables comments in such way that it is possible to identify when the rules were added.
+// formatComment is used to format iptables comments in such way that it is possible to identify when the rules were added.
 // This helps debug when iptables has some stale rules from previous runs, something that can happen frequently on minikube.
 func formatComment(text string) string {
 	return fmt.Sprintf("proxy-init/%s/%s", text, ExecutionTraceID)
@@ -119,7 +118,7 @@ func addOutgoingTrafficRules(commands []*exec.Cmd, firewallConfiguration Firewal
 	log.Infof("Redirecting all OUTPUT to %d", firewallConfiguration.ProxyOutgoingPort)
 	commands = append(commands, makeRedirectChainToPort(outputChainName, firewallConfiguration.ProxyOutgoingPort, "redirect-all-outgoing-to-proxy-port"))
 
-	//Redirect all remaining outbound traffic to the proxy.
+	// Redirect all remaining outbound traffic to the proxy.
 	commands = append(
 		commands,
 		makeJumpFromChainToAnotherForAllProtocols(
@@ -136,7 +135,7 @@ func addIncomingTrafficRules(commands []*exec.Cmd, firewallConfiguration Firewal
 	commands = addRulesForIgnoredPorts(firewallConfiguration.InboundPortsToIgnore, redirectChainName, commands)
 	commands = addRulesForInboundPortRedirect(firewallConfiguration, redirectChainName, commands)
 
-	//Redirect all remaining inbound traffic to the proxy.
+	// Redirect all remaining inbound traffic to the proxy.
 	commands = append(
 		commands,
 		makeJumpFromChainToAnotherForAllProtocols(
@@ -151,7 +150,7 @@ func addIncomingTrafficRules(commands []*exec.Cmd, firewallConfiguration Firewal
 func addRulesForInboundPortRedirect(firewallConfiguration FirewallConfiguration, chainName string, commands []*exec.Cmd) []*exec.Cmd {
 	if firewallConfiguration.Mode == RedirectAllMode {
 		log.Info("Will redirect all INPUT ports to proxy")
-		//Create a new chain for redirecting inbound and outbound traffic to the proxy port.
+		// Create a new chain for redirecting inbound and outbound traffic to the proxy port.
 		commands = append(commands, makeRedirectChainToPort(chainName,
 			firewallConfiguration.ProxyInboundPort,
 			"redirect-all-incoming-to-proxy-port"))


### PR DESCRIPTION
Changes the image for being able to run linkerd without CNI as non-root

* adds libcap and sets capabilities on binaries required for non-root
* set USER to uid of nobody to run as non-root per default
* replace usage of `iptables-save` by `iptables -t nat -L`

New PR to continue work initially done at #31.

Credits to @pankajmt which did the initial implementation.

I set the default user to the uid of `nobody`.
I did use the uid because otherwise kubernetes requires us to set `runAsUser` explicitly because a non-numeric user is not proven to not being root.

<sup>
Christian Schlotter <christian.schlotter@daimler.com>, Daimler TSS GmbH, 
<a href="https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md">Provider Information</a>
</sup>