### PR TITLE
Update base container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM --platform=$BUILDPLATFORM golang:1.16.2 as golang
+FROM --platform=$BUILDPLATFORM golang:1.16.9-alpine3.14 as golang
 WORKDIR /build
 
 # cache dependencies
@@ -13,7 +13,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/linkerd2-proxy-init -mod=readonly -ldflags "-s -w" -v
 
 ## package runtime
-FROM --platform=$TARGETPLATFORM alpine:20210212
+FROM --platform=$TARGETPLATFORM alpine:3.14.2
 RUN apk add iptables libcap
 RUN touch /run/xtables.lock && chmod 0666 /run/xtables.lock
 RUN setcap cap_net_raw,cap_net_admin+eip /sbin/xtables-legacy-multi


### PR DESCRIPTION
The alpine image used by `linkerd-proxy-init` includes some vulnerable
packages. Even though these packages are not actively used, it's worth
updating the base image to a more recent version.

This change also updates to `golang` base image to from 1.16.2 to
1.16.9-alpine3.14. This way we build everything on the same platform
that it runs on and also minimize the size of the container image.