### PR TITLE
Add DCO and CODEOWNERS configurations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# By default, the maintainers group is responsible for everything.
+*   @linkerd/maintainers

--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false


### PR DESCRIPTION
This change copies the `linkerd2` repo's CODEOWNERS and dco.yml files so
that maintainers are automatically included in PR reviews and so that
organization members are not required to add a DCO signoff.