### PR TITLE
Add option to skip subnets

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -17,6 +17,7 @@ func TestBuildFirewallConfiguration(t *testing.T) {
 			PortsToRedirectInbound: make([]int, 0),
 			InboundPortsToIgnore:   make([]string, 0),
 			OutboundPortsToIgnore:  make([]string, 0),
+			SubnetsToIgnore:        make([]string, 0),
 			ProxyInboundPort:       expectedIncomingProxyPort,
 			ProxyOutgoingPort:      expectedOutgoingProxyPort,
 			ProxyUID:               expectedProxyUserID,
@@ -71,6 +72,12 @@ func TestBuildFirewallConfiguration(t *testing.T) {
 					OutgoingProxyPort: 100000,
 				},
 				errorMessage: "--outgoing-proxy-port must be a valid TCP port number",
+			},
+			{
+				options: &RootOptions{
+					SubnetsToIgnore: []string{"1.1.1.1/24", "0.0.0.0"},
+				},
+				errorMessage: "0.0.0.0 is not a valid CIDR address",
 			},
 		} {
 			_, err := BuildFirewallConfiguration(tt.options)

--- a/integration_test/iptables/http_test.go
+++ b/integration_test/iptables/http_test.go
@@ -177,6 +177,30 @@ func TestPodMakesOutboundConnection(t *testing.T) {
 	})
 }
 
+func TestPodWithSomeSubnetsIgnored(t *testing.T) {
+	t.Parallel()
+
+	podIgnoredSomeSubnetsIP := os.Getenv("POD_IGNORES_SUBNETS_IP")
+
+	t.Run("connecting to a not-a-proxy-container should bypass proxy container", func(t *testing.T) {
+		response := expectSuccessfulGetRequestTo(t, podIgnoredSomeSubnetsIP, notTheProxyContainerPort)
+
+		expectedResponse := fmt.Sprintf("pod-ignores-subnets:%s", notTheProxyContainerPort)
+		if !strings.Contains(response, expectedResponse) {
+			t.Fatalf("Expected response to be bypassed, expected %s but it was %s", expectedResponse, response)
+		}
+	})
+
+	t.Run("connecting directly to the proxy container pod should still work", func(t *testing.T) {
+		response := expectSuccessfulGetRequestTo(t, podIgnoredSomeSubnetsIP, proxyContainerPort)
+
+		expectedResponse := "proxy"
+		if !strings.Contains(response, expectedResponse) {
+			t.Fatalf("Expected response from the proxy container, expected %s but it was %s", expectedResponse, response)
+		}
+	})
+}
+
 func makeCallFromContainerToAnother(t *testing.T, fromPodNamed string, fromContainerAtPort string, podIWantToReachName string, containerPortIWantToReach string) string {
 	downstreamURL := fmt.Sprintf("http://%s:%s", podIWantToReachName, containerPortIWantToReach)
 

--- a/integration_test/iptables/iptablestest-lab.yaml
+++ b/integration_test/iptables/iptablestest-lab.yaml
@@ -274,3 +274,56 @@ spec:
   volumes:
   - emptyDir: {}
     name: linkerd-proxy-init-xtables-lock
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-ignores-subnets
+  labels:
+    app: pod-ignores-subnets
+spec:
+  containers:
+  - name: proxy-stub
+    image: ghcr.io/linkerd/iptables-tester:v1
+    env:
+    - name: PORT
+      value: "8080"
+    - name: AM_I_THE_PROXY
+      value: "yes"
+    command: ["go", "run", "/go/test_service/test_service.go"]
+    ports:
+    - name: http
+      containerPort: 8080
+    securityContext:
+      privileged: false
+      runAsUser: 2102
+  - name: other-container
+    image: ghcr.io/linkerd/iptables-tester:v1
+    env:
+    - name: PORT
+      value: "9090"
+    command: ["go", "run", "/go/test_service/test_service.go"]
+    ports:
+    - name: http
+      containerPort: 9090
+  initContainers:
+  - name: linkerd-init
+    image: ghcr.io/linkerd/proxy-init:latest
+    imagePullPolicy: Never
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "--subnets-to-ignore", "0.0.0.0/0"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: false
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /run
+      name: linkerd-proxy-init-xtables-lock
+  volumes:
+  - emptyDir: {}
+    name: linkerd-proxy-init-xtables-lock

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -60,6 +60,9 @@ log "POD_REDIRECTS_WHITELISTED_IP=${POD_REDIRECTS_WHITELISTED_IP}"
 POD_DOEST_REDIRECT_BLACKLISTED_IP=$(get_ip_for_pod 'pod-doesnt-redirect-blacklisted')
 log "POD_DOEST_REDIRECT_BLACKLISTED_IP=${POD_DOEST_REDIRECT_BLACKLISTED_IP}"
 
+POD_IGNORES_SUBNETS_IP=$(get_ip_for_pod 'pod-ignores-subnets')
+log "POD_IGNORES_SUBNETS_IP=${POD_IGNORES_SUBNETS_IP}"
+
 header 'Running tester...'
 cat <<EOF | kubectl create -f -
 apiVersion: batch/v1
@@ -85,6 +88,8 @@ spec:
             value: ${POD_REDIRECTS_WHITELISTED_IP}
           - name: POD_DOEST_REDIRECT_BLACKLISTED_IP
             value: ${POD_DOEST_REDIRECT_BLACKLISTED_IP}
+          - name: POD_IGNORES_SUBNETS_IP
+            value: ${POD_IGNORES_SUBNETS_IP}
       restartPolicy: Never
 EOF
 


### PR DESCRIPTION
Add a flag `--subnets-to-ignore` to skip subnets from redirecting to linkerd proxy

```bash
linkerd-init --subnets-to-ignore 172.17.0.0/16,172.17.0.1/32
```

This is done by appending one or many iptables rules that `RETURN` on ignored subnets before appending the [addRulesForInboundPortRedirect](https://github.com/linkerd/linkerd2-proxy-init/blob/51fb222dd8c737d3e739905741d5d60b4719a2f3/iptables/iptables.go#L136).

The goal is to support running linkerd with dind containers

Fixes https://github.com/linkerd/linkerd2/issues/6758

Signed-off-by: Michael Lin <mlzc@hey.com>

----

Example

```yaml
initContainers:
  - name: linkerd-init
    args:
      - --subnets-to-ignore
      - 172.17.0.0/16,172.17.0.1/32 # `/32` is probably a horrible example, but whatever...
```

`PROXY_INIT_REDIRECT` chain

```
Chain PROXY_INIT_REDIRECT (1 references)
num  target     prot opt source               destination
1    RETURN     tcp  --  anywhere             anywhere             multiport dports 4190,4191 /* proxy-init/ignore-port-4190,4191/1636093203 */
2    RETURN     all  --  172.17.0.0/16        anywhere             /* proxy-init/ignore-subnet-172.17.0.0/16/1636093203 */
3    RETURN     all  --  172.17.0.1           anywhere             /* proxy-init/ignore-subnet-172.17.0.1/32/1636093203 */
4    REDIRECT   tcp  --  anywhere             anywhere             /* proxy-init/redirect-all-incoming-to-proxy-port/1636093203 */ redir ports 4143
```

Logs from the init container

```
time="2021-11-05T06:20:03Z" level=info msg="iptables-save -t nat"
time="2021-11-05T06:20:03Z" level=info msg="# Generated by iptables-save v1.8.7 on Fri Nov  5 06:20:03 2021\n*nat\n:PREROUTING ACCEPT [0:0]\n:INPUT ACCEPT [0:0]\n:OUTPUT ACCEPT [0:0]\n:POSTROUTING ACCEPT [0:0]\nCOMMIT\n# Completed on Fri Nov  5 06:20:03 2021\n"
time="2021-11-05T06:20:03Z" level=info msg="Will ignore port [4190 4191] on chain PROXY_INIT_REDIRECT"
time="2021-11-05T06:20:03Z" level=info msg="Will ignore subnet 172.17.0.0/16 on chain PROXY_INIT_REDIRECT"
time="2021-11-05T06:20:03Z" level=info msg="Will ignore subnet 172.17.0.1/32 on chain PROXY_INIT_REDIRECT"
time="2021-11-05T06:20:03Z" level=info msg="Will redirect all INPUT ports to proxy"
time="2021-11-05T06:20:03Z" level=info msg="Ignoring uid 2102"
time="2021-11-05T06:20:03Z" level=info msg="Redirecting all OUTPUT to 4140"
time="2021-11-05T06:20:03Z" level=info msg="iptables -t nat -N PROXY_INIT_REDIRECT -m comment --comment proxy-init/redirect-common-chain/1636093203"
time="2021-11-05T06:20:03Z" level=info msg="iptables -t nat -A PROXY_INIT_REDIRECT -p tcp --match multiport --dports 4190,4191 -j RETURN -m comment --comment proxy-init/ignore-port-4190,4191/1636093203"
time="2021-11-05T06:20:03Z" level=info msg="iptables -t nat -A PROXY_INIT_REDIRECT -p all -j RETURN -s 172.17.0.0/16 -m comment --comment proxy-init/ignore-subnet-172.17.0.0/16/1636093203"
time="2021-11-05T06:20:03Z" level=info msg="iptables -t nat -A PROXY_INIT_REDIRECT -p all -j RETURN -s 172.17.0.1/32 -m comment --comment proxy-init/ignore-subnet-172.17.0.1/32/1636093203"
time="2021-11-05T06:20:03Z" level=info msg="iptables -t nat -A PROXY_INIT_REDIRECT -p tcp -j REDIRECT --to-port 4143 -m comment --comment proxy-init/redirect-all-incoming-to-proxy-port/1636093203"
time="2021-11-05T06:20:04Z" level=info msg="iptables -t nat -A PREROUTING -j PROXY_INIT_REDIRECT -m comment --comment proxy-init/install-proxy-init-prerouting/1636093203"
time="2021-11-05T06:20:04Z" level=info msg="iptables -t nat -N PROXY_INIT_OUTPUT -m comment --comment proxy-init/redirect-common-chain/1636093203"
time="2021-11-05T06:20:04Z" level=info msg="iptables -t nat -A PROXY_INIT_OUTPUT -m owner --uid-owner 2102 -j RETURN -m comment --comment proxy-init/ignore-proxy-user-id/1636093203"
time="2021-11-05T06:20:04Z" level=info msg="iptables -t nat -A PROXY_INIT_OUTPUT -o lo -j RETURN -m comment --comment proxy-init/ignore-loopback/1636093203"
time="2021-11-05T06:20:04Z" level=info msg="iptables -t nat -A PROXY_INIT_OUTPUT -p tcp -j REDIRECT --to-port 4140 -m comment --comment proxy-init/redirect-all-outgoing-to-proxy-port/1636093203"
time="2021-11-05T06:20:04Z" level=info msg="iptables -t nat -A OUTPUT -j PROXY_INIT_OUTPUT -m comment --comment proxy-init/install-proxy-init-output/1636093203"
time="2021-11-05T06:20:04Z" level=info msg="iptables-save -t nat"
time="2021-11-05T06:20:04Z" level=info msg="# Generated by iptables-save v1.8.7 on Fri Nov  5 06:20:04 2021\n*nat\n:PREROUTING ACCEPT [0:0]\n:INPUT ACCEPT [0:0]\n:OUTPUT ACCEPT [0:0]\n:POSTROUTING ACCEPT [0:0]\n:PROXY_INIT_OUTPUT - [0:0]\n:PROXY_INIT_REDIRECT - [0:0]\n-A PREROUTING -m comment --comment \"proxy-init/install-proxy-init-prerouting/1636093203\" -j PROXY_INIT_REDIRECT\n-A OUTPUT -m comment --comment \"proxy-init/install-proxy-init-output/1636093203\" -j PROXY_INIT_OUTPUT\n-A PROXY_INIT_OUTPUT -m owner --uid-owner 2102 -m comment --comment \"proxy-init/ignore-proxy-user-id/1636093203\" -j RETURN\n-A PROXY_INIT_OUTPUT -o lo -m comment --comment \"proxy-init/ignore-loopback/1636093203\" -j RETURN\n-A PROXY_INIT_OUTPUT -p tcp -m comment --comment \"proxy-init/redirect-all-outgoing-to-proxy-port/1636093203\" -j REDIRECT --to-ports 4140\n-A PROXY_INIT_REDIRECT -p tcp -m multiport --dports 4190,4191 -m comment --comment \"proxy-init/ignore-port-4190,4191/1636093203\" -j RETURN\n-A PROXY_INIT_REDIRECT -s 172.17.0.0/16 -m comment --comment \"proxy-init/ignore-subnet-172.17.0.0/16/1636093203\" -j RETURN\n-A PROXY_INIT_REDIRECT -s 172.17.0.1/32 -m comment --comment \"proxy-init/ignore-subnet-172.17.0.1/32/1636093203\" -j RETURN\n-A PROXY_INIT_REDIRECT -p tcp -m comment --comment \"proxy-init/redirect-all-incoming-to-proxy-port/1636093203\" -j REDIRECT --to-ports 4143\nCOMMIT\n# Completed on Fri Nov  5 06:20:04 2021\n"
```