### PR TITLE
Lowercase logs and remove redundant lines

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -84,7 +84,6 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 
 	for _, cmd := range commands {
 		if err := executeCommand(firewallConfiguration, cmd, nil); err != nil {
-			log.Error("aborting firewall configuration: %v", err)
 			return err
 		}
 	}


### PR DESCRIPTION
Our current logging set-up was a bit confusing when debugging. When going through each command and setting chains or rules up, we'd log what we are doing. When the commands executed, if a command failed for whatever reason, we would also get both the command and its output printed. This is a bit confusing since in practice we log all of the commands but then the failure may happen at _any_ command making it harder to pinpoint the issue.

I also lowercased everything to make it easier to grep/search.

Signed-off-by: Matei David <matei@buoyant.io>