### PR TITLE
Add iptables-nft support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,10 +24,11 @@ type RootOptions struct {
 	SimulateOnly          bool
 	NetNs                 string
 	UseWaitFlag           bool
-	UseNFTBackend         bool
 	TimeoutCloseWaitSecs  int
 	LogFormat             string
 	LogLevel              string
+	FirewallBinPath       string
+	FirewallSaveBinPath   string
 }
 
 func newRootOptions() *RootOptions {
@@ -42,10 +43,11 @@ func newRootOptions() *RootOptions {
 		SimulateOnly:          false,
 		NetNs:                 "",
 		UseWaitFlag:           false,
-		UseNFTBackend:         false,
 		TimeoutCloseWaitSecs:  0,
 		LogFormat:             "plain",
 		LogLevel:              "info",
+		FirewallBinPath:       "/sbin/iptables",
+		FirewallSaveBinPath:   "/sbin/iptables-save",
 	}
 }
 
@@ -96,10 +98,11 @@ func NewRootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&options.SimulateOnly, "simulate", options.SimulateOnly, "Don't execute any command, just print what would be executed")
 	cmd.PersistentFlags().StringVar(&options.NetNs, "netns", options.NetNs, "Optional network namespace in which to run the iptables commands")
 	cmd.PersistentFlags().BoolVarP(&options.UseWaitFlag, "use-wait-flag", "w", options.UseWaitFlag, "Appends the \"-w\" flag to the iptables commands")
-	cmd.PersistentFlags().BoolVar(&options.UseNFTBackend, "use-nft-backend", options.UseNFTBackend, "Uses iptables-nft to configure routing")
 	cmd.PersistentFlags().IntVar(&options.TimeoutCloseWaitSecs, "timeout-close-wait-secs", options.TimeoutCloseWaitSecs, "Sets nf_conntrack_tcp_timeout_close_wait")
 	cmd.PersistentFlags().StringVar(&options.LogFormat, "log-format", options.LogFormat, "Configure log format ('plain' or 'json')")
 	cmd.PersistentFlags().StringVar(&options.LogLevel, "log-level", options.LogLevel, "Configure log level")
+	cmd.PersistentFlags().StringVar(&options.FirewallBinPath, "firewall-bin-path", options.FirewallBinPath, "Path to iptables binary")
+	cmd.PersistentFlags().StringVar(&options.FirewallSaveBinPath, "firewall-save-bin-path", options.FirewallSaveBinPath, "Path to iptables-save binary")
 	return cmd
 }
 
@@ -131,7 +134,8 @@ func BuildFirewallConfiguration(options *RootOptions) (*iptables.FirewallConfigu
 		SimulateOnly:           options.SimulateOnly,
 		NetNs:                  options.NetNs,
 		UseWaitFlag:            options.UseWaitFlag,
-		UseNFTBackend:          options.UseNFTBackend,
+		BinPath:                options.FirewallBinPath,
+		SaveBinPath:            options.FirewallSaveBinPath,
 	}
 
 	if len(options.PortsToRedirect) > 0 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ type RootOptions struct {
 	SimulateOnly          bool
 	NetNs                 string
 	UseWaitFlag           bool
+	UseNFTBackend         bool
 	TimeoutCloseWaitSecs  int
 	LogFormat             string
 	LogLevel              string
@@ -41,6 +42,7 @@ func newRootOptions() *RootOptions {
 		SimulateOnly:          false,
 		NetNs:                 "",
 		UseWaitFlag:           false,
+		UseNFTBackend:         false,
 		TimeoutCloseWaitSecs:  0,
 		LogFormat:             "plain",
 		LogLevel:              "info",
@@ -94,6 +96,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&options.SimulateOnly, "simulate", options.SimulateOnly, "Don't execute any command, just print what would be executed")
 	cmd.PersistentFlags().StringVar(&options.NetNs, "netns", options.NetNs, "Optional network namespace in which to run the iptables commands")
 	cmd.PersistentFlags().BoolVarP(&options.UseWaitFlag, "use-wait-flag", "w", options.UseWaitFlag, "Appends the \"-w\" flag to the iptables commands")
+	cmd.PersistentFlags().BoolVar(&options.UseNFTBackend, "use-nft-backend", options.UseNFTBackend, "Uses iptables-nft to configure routing")
 	cmd.PersistentFlags().IntVar(&options.TimeoutCloseWaitSecs, "timeout-close-wait-secs", options.TimeoutCloseWaitSecs, "Sets nf_conntrack_tcp_timeout_close_wait")
 	cmd.PersistentFlags().StringVar(&options.LogFormat, "log-format", options.LogFormat, "Configure log format ('plain' or 'json')")
 	cmd.PersistentFlags().StringVar(&options.LogLevel, "log-level", options.LogLevel, "Configure log level")
@@ -128,6 +131,7 @@ func BuildFirewallConfiguration(options *RootOptions) (*iptables.FirewallConfigu
 		SimulateOnly:           options.SimulateOnly,
 		NetNs:                  options.NetNs,
 		UseWaitFlag:            options.UseWaitFlag,
+		UseNFTBackend:          options.UseNFTBackend,
 	}
 
 	if len(options.PortsToRedirect) > 0 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,8 +46,8 @@ func newRootOptions() *RootOptions {
 		TimeoutCloseWaitSecs:  0,
 		LogFormat:             "plain",
 		LogLevel:              "info",
-		FirewallBinPath:       "/sbin/iptables",
-		FirewallSaveBinPath:   "/sbin/iptables-save",
+		FirewallBinPath:       "iptables",
+		FirewallSaveBinPath:   "iptables-save",
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -23,8 +23,8 @@ func TestBuildFirewallConfiguration(t *testing.T) {
 			ProxyUID:               expectedProxyUserID,
 			SimulateOnly:           false,
 			UseWaitFlag:            false,
-			BinPath:                "/sbin/iptables",
-			SaveBinPath:            "/sbin/iptables-save",
+			BinPath:                "iptables",
+			SaveBinPath:            "iptables-save",
 		}
 
 		options := newRootOptions()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -23,6 +23,8 @@ func TestBuildFirewallConfiguration(t *testing.T) {
 			ProxyUID:               expectedProxyUserID,
 			SimulateOnly:           false,
 			UseWaitFlag:            false,
+			BinPath:                "/sbin/iptables",
+			SaveBinPath:            "/sbin/iptables-save",
 		}
 
 		options := newRootOptions()

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -68,7 +68,7 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 	log.Debugf("setting up iptables routing by calling into '%s'", iptablesBin)
 
 	b := bytes.Buffer{}
-	if err := executeCommand(iptablesBin, firewallConfiguration, makeShowAllRules(iptablesBin), &b); err != nil {
+	if err := executeCommand(iptablesBin, firewallConfiguration, makeShowAllRules(firewallConfiguration.UseNFTBackend), &b); err != nil {
 		log.Error("aborting firewall configuration")
 		return err
 	}
@@ -92,7 +92,7 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 		}
 	}
 
-	_ = executeCommand(iptablesBin, firewallConfiguration, makeShowAllRules(iptablesBin), nil)
+	_ = executeCommand(iptablesBin, firewallConfiguration, makeShowAllRules(firewallConfiguration.UseNFTBackend), nil)
 
 	return nil
 }
@@ -354,7 +354,12 @@ func makeJumpFromChainToAnotherForAllProtocols(bin string, chainName string, tar
 		"--comment", formatComment(comment))
 }
 
-func makeShowAllRules(bin string) *exec.Cmd {
+func makeShowAllRules(useNft bool) *exec.Cmd {
+	bin := "iptables-save"
+	if useNft {
+		bin = "iptables-nft-save"
+	}
+
 	return exec.Command(bin, "-t", "nat")
 }
 

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -215,7 +215,7 @@ func makeMultiportDestinations(portsToIgnore []string) [][]string {
 }
 
 func executeCommand(firewallConfiguration FirewallConfiguration, cmd *exec.Cmd, cmdOut io.Writer) error {
-	if cmd.Path == firewallConfiguration.BinPath && firewallConfiguration.UseWaitFlag {
+	if strings.Contains(cmd.Path, "iptables") && firewallConfiguration.UseWaitFlag {
 		log.Info("'useWaitFlag' set: iptables will wait for xtables to become available")
 		cmd.Args = append(cmd.Args, "-w")
 	}

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -361,13 +361,3 @@ func asDestination(portRange ports.PortRange) string {
 
 	return fmt.Sprintf("%d:%d", portRange.LowerBound, portRange.UpperBound)
 }
-
-// getBinaryName will return the name of the iptables binary to call into,
-// depending on whether the NFT Kernel API mode is on.
-func getBinaryName(useNft bool) string {
-	bin := "iptables"
-	if useNft {
-		bin = "iptables-nft"
-	}
-	return bin
-}


### PR DESCRIPTION
This change introduces support for iptables-nft. To support backwards
compatibility, iptables-nft usage is optional and off by default.

This PR introduces two new flags "--firewall-binary-path" and 
"--firewall-save-binary-path".  The two flags will be used when
calling into iptables binaries: 'iptables' and 'iptables-save' respectively.

The path can be overridden to call into iptables-nft, which will itself 
be present in the alpine container once the iptables package is installed.
To support the change, all firewall config functions have been changed
into methods.

Signed-off-by: Matei David <matei@buoyant.io>

---


## Testing

Tested using `k3d` on Debian. InitContainer worked well with defaults (i.e calling into legacy binary). Changed the args to use nft save and nft iptables and it worked well too:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: curl
spec:
  selector:
    matchLabels:
      app: curl
  template:
    metadata:
      annotations:
        config.linkerd.io/proxy-log-level: linkerd=debug,warn
        linkerd.io/created-by: linkerd/cli stable-2.11.2
        linkerd.io/identity-mode: default
        linkerd.io/proxy-version: stable-2.11.2
      labels:
        app: curl
        linkerd.io/control-plane-ns: linkerd
        linkerd.io/proxy-deployment: curl
        linkerd.io/workload-ns: ""
    spec:
      containers:
      - env:
        - name: _pod_name
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        - name: _pod_ns
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: _pod_nodeName
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        - name: LINKERD2_PROXY_LOG
          value: linkerd=debug,warn
        - name: LINKERD2_PROXY_LOG_FORMAT
          value: plain
        - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
          value: linkerd-dst-headless.linkerd.svc.cluster.local.:8086
        - name: LINKERD2_PROXY_DESTINATION_PROFILE_NETWORKS
          value: 10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16
        - name: LINKERD2_PROXY_POLICY_SVC_ADDR
          value: linkerd-policy.linkerd.svc.cluster.local.:8090
        - name: LINKERD2_PROXY_POLICY_WORKLOAD
          value: $(_pod_ns):$(_pod_name)
        - name: LINKERD2_PROXY_INBOUND_DEFAULT_POLICY
          value: all-unauthenticated
        - name: LINKERD2_PROXY_POLICY_CLUSTER_NETWORKS
          value: 10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16
        - name: LINKERD2_PROXY_INBOUND_CONNECT_TIMEOUT
          value: 100ms
        - name: LINKERD2_PROXY_OUTBOUND_CONNECT_TIMEOUT
          value: 1000ms
        - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
          value: 0.0.0.0:4190
        - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
          value: 0.0.0.0:4191
        - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
          value: 127.0.0.1:4140
        - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
          value: 0.0.0.0:4143
        - name: LINKERD2_PROXY_INBOUND_IPS
          valueFrom:
            fieldRef:
              fieldPath: status.podIPs
        - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
          value: svc.cluster.local.
        - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
          value: 10000ms
        - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
          value: 10000ms
        - name: LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION
          value: 25,587,3306,4444,5432,6379,9300,11211
        - name: LINKERD2_PROXY_DESTINATION_CONTEXT
          value: |
            {"ns":"$(_pod_ns)", "nodeName":"$(_pod_nodeName)"}
        - name: _pod_sa
          valueFrom:
            fieldRef:
              fieldPath: spec.serviceAccountName
        - name: _l5d_ns
          value: linkerd
        - name: _l5d_trustdomain
          value: cluster.local
        - name: LINKERD2_PROXY_IDENTITY_DIR
          value: /var/run/linkerd/identity/end-entity
        - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
          value: |
            -----BEGIN CERTIFICATE-----
            MIIBiDCCAS6gAwIBAgIBATAKBggqhkjOPQQDAjAcMRowGAYDVQQDExFpZGVudGl0
            eS5saW5rZXJkLjAeFw0yMjA3MDYxNjUwMDFaFw0yMzA3MDYxNjUwMjFaMBwxGjAY
            BgNVBAMTEWlkZW50aXR5LmxpbmtlcmQuMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcD
            QgAEv0DFbBROE+An2+hfcKEcQvnRtR4ej34xiNcwJ3Tb9W6NQzVmGRX2KtLDk9Br
            +8b3pvV9X+KTJvcKnStP0WGhi6NhMF8wDgYDVR0PAQH/BAQDAgEGMB0GA1UdJQQW
            MBQGCCsGAQUFBwMBBggrBgEFBQcDAjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQW
            BBQE4D9pBdY9gCChuYMaTm/nQsSoyTAKBggqhkjOPQQDAgNIADBFAiAY4J4yIw6f
            5L3XVvmENHjLWmn7Lq710u+q9/UeSDaoKwIhAN0+JvcNOL5tBVsXj2MMDPIiHx2X
            hWaV4zYrYXe4jceN
            -----END CERTIFICATE-----
        - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
          value: /var/run/secrets/kubernetes.io/serviceaccount/token
        - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
          value: linkerd-identity-headless.linkerd.svc.cluster.local.:8080
        - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
          value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.linkerd.cluster.local
        - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
          value: linkerd-identity.linkerd.serviceaccount.identity.linkerd.cluster.local
        - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
          value: linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local
        - name: LINKERD2_PROXY_POLICY_SVC_NAME
          value: linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local
        image: cr.l5d.io/linkerd/proxy:stable-2.11.2
        imagePullPolicy: IfNotPresent
        lifecycle:
          postStart:
            exec:
              command:
              - /usr/lib/linkerd/linkerd-await
              - --timeout=2m
        livenessProbe:
          httpGet:
            path: /live
            port: 4191
          initialDelaySeconds: 10
        name: linkerd-proxy
        ports:
        - containerPort: 4143
          name: linkerd-proxy
        - containerPort: 4191
          name: linkerd-admin
        readinessProbe:
          httpGet:
            path: /ready
            port: 4191
          initialDelaySeconds: 2
        securityContext:
          allowPrivilegeEscalation: false
          readOnlyRootFilesystem: true
          runAsUser: 2102
        terminationMessagePolicy: FallbackToLogsOnError
        volumeMounts:
        - mountPath: /var/run/linkerd/identity/end-entity
          name: linkerd-identity-end-entity
      - command:
        - /bin/sleep
        - 3650d
        image: curlimages/curl
        imagePullPolicy: IfNotPresent
        name: curl
      initContainers:
      - args:
        - --incoming-proxy-port
        - "4143"
        - --outgoing-proxy-port
        - "4140"
        - --proxy-uid
        - "2102"
        - --inbound-ports-to-ignore
        - 4190,4191,4567,4568
        - --outbound-ports-to-ignore
        - 4567,4568
        image: ghcr.io/linkerd/proxy-init:latest
        imagePullPolicy: IfNotPresent
        name: linkerd-init
        resources:
          limits:
            cpu: 100m
            memory: 50Mi
          requests:
            cpu: 10m
            memory: 10Mi
        securityContext:
          allowPrivilegeEscalation: true
          capabilities:
            add:
            - NET_ADMIN
            - NET_RAW
          privileged: false
          readOnlyRootFilesystem: true
          runAsNonRoot: false
          runAsUser: 0
        terminationMessagePolicy: FallbackToLogsOnError
        volumeMounts:
        - mountPath: /run
          name: linkerd-proxy-init-xtables-lock
      restartPolicy: Always
      volumes:
      - emptyDir: {}
        name: linkerd-proxy-init-xtables-lock
      - emptyDir:
          medium: Memory
        name: linkerd-identity-end-entity
```

```sh
:; k logs curl-865fb48767-tfmt6 linkerd-init
time="2022-07-12T14:06:53Z" level=debug msg="tracing script execution as [1657634813]"
time="2022-07-12T14:06:53Z" level=debug msg="using '/sbin/iptables-nft' to set-up firewall rules"
time="2022-07-12T14:06:53Z" level=debug msg="using '/sbin/iptables-nft-save' to list all available rules"
```

```sh
:; k exec curl-865fb48767-tfmt6 -it -c curl -- curl http://nginx-svc:80
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
html { color-scheme: light dark; }
body { width: 35em; margin: 0 auto;
font-family: Tahoma, Verdana, Arial, sans-serif; }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>
```