### PR TITLE
Add sys net caps to xtables-nft-multi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/linkerd2-proxy-
 FROM --platform=$TARGETPLATFORM alpine:3.14.2
 RUN apk add iptables libcap
 RUN touch /run/xtables.lock && chmod 0666 /run/xtables.lock
-RUN setcap cap_net_raw,cap_net_admin+eip /sbin/xtables-legacy-multi
+RUN setcap cap_net_raw,cap_net_admin+eip /sbin/xtables-legacy-multi && \
+    setcap cap_net_raw,cap_net_admin+eip /sbin/xtables-nft-multi
 COPY LICENSE /linkerd/LICENSE
 COPY --from=golang /out/linkerd2-proxy-init /usr/local/bin/proxy-init
 RUN setcap cap_net_raw,cap_net_admin+eip /usr/local/bin/proxy-init


### PR DESCRIPTION
Both iptables and iptables-nft use the same packet matching code in the
kernel (xtables). iptables binaries are symbolic links to the respective
xtables binaries; for example, iptables-legacy would be a symbolic link
to xtables-legacy-multi, and likewise, iptables-nft a symbolic link to
xtables-nft-multi.

To support running the container as non-root in Kubernetes, instead of
adding system capabilities in the pod spec, they have been baked into
the image; xtables-legacy-multi has been granted both net_admin and
net_raw capabilities. To preserve the same behaviour when using
nftables, this change adds the same capabilities to the
xtables-nft-multi binary.

Signed-off-by: Matei David <matei@buoyant.io>