### PR TITLE
Add Docker Cache Prune to just recipe

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -16,8 +16,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb
-      with:
-        just-version: 1.2.0
     - uses: AbsaOSS/k3d-action@b176c2a6dcae72e3e64e3e4d61751904ec314002
       name: "Create k3d cluster"
       with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -7,6 +7,10 @@ on:
     - '**/*.md'
     branches:
     - master
+
+env:
+  DOCKER_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
+
 jobs:
   integration_tests:
     name: Proxy Init Integration Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb
-      with:
-        just-version: 1.2.0
     - name: Set env variables
       shell: bash
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+    - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb
+      with:
+        just-version: 1.2.0
     - name: Set env variables
       shell: bash
       run: |
@@ -57,4 +60,4 @@ jobs:
       run: cosign sign "ghcr.io/linkerd/proxy-init:$TAG"
     - name: Prune docker layers cache
       shell: bash
-      run: bin/docker-cache-prune
+      run: just docker-cache-prune

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -29,7 +29,5 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb
-      with:
-        just-version: 1.2.0
     - name: Go Fmt
       run: just fmt

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,7 +17,5 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb
-      with:
-        just-version: 1.2.0
     - name: Run unit tests
       run: just test-unit

--- a/integration_test/iptables/iptablestest-lab.yaml
+++ b/integration_test/iptables/iptablestest-lab.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: webserver
-    image: cr.l5d.io/linkerd/iptables-tester:v1
+    image: ghcr.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "8080"
@@ -17,7 +17,7 @@ spec:
     - name: http
       containerPort: 8080
   - name: other-container
-    image: cr.l5d.io/linkerd/iptables-tester:v1
+    image: ghcr.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "9090"
@@ -46,7 +46,7 @@ metadata:
 spec:
   containers:
   - name: webserver
-    image: cr.l5d.io/linkerd/iptables-tester:v1
+    image: ghcr.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "8080"
@@ -55,7 +55,7 @@ spec:
     - name: http
       containerPort: 8080
   - name: other-container
-    image: cr.l5d.io/linkerd/iptables-tester:v1
+    image: ghcr.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "9090"
@@ -68,7 +68,7 @@ spec:
   # iptable rules are run more than once. The linkerd-init container
   # should log "Found existing firewall configuration..."
   - name: iptables-test
-    image: cr.l5d.io/linkerd/proxy-init:latest
+    image: ghcr.io/linkerd/proxy-init:latest
     imagePullPolicy: IfNotPresent
     args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
     securityContext:
@@ -85,7 +85,7 @@ spec:
     - mountPath: /run
       name: linkerd-proxy-init-xtables-lock
   - name: linkerd-init
-    image: cr.l5d.io/linkerd/proxy-init:latest
+    image: ghcr.io/linkerd/proxy-init:latest
     imagePullPolicy: IfNotPresent
     args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
     securityContext:
@@ -114,7 +114,7 @@ metadata:
 spec:
   containers:
   - name: other-container
-    image: cr.l5d.io/linkerd/iptables-tester:v1
+    image: ghcr.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "9090"
@@ -123,7 +123,7 @@ spec:
     - name: http
       containerPort: 9090
   - name: proxy-stub
-    image: cr.l5d.io/linkerd/iptables-tester:v1
+    image: ghcr.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "8080"
@@ -138,7 +138,7 @@ spec:
       containerPort: 8080
   initContainers:
   - name: linkerd-init
-    image: cr.l5d.io/linkerd/proxy-init:latest
+    image: ghcr.io/linkerd/proxy-init:latest
     imagePullPolicy: IfNotPresent
     args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
     securityContext:
@@ -178,7 +178,7 @@ metadata:
 spec:
   containers:
   - name: proxy-stub
-    image: cr.l5d.io/linkerd/iptables-tester:v1
+    image: ghcr.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "8080"
@@ -193,7 +193,7 @@ spec:
       runAsUser: 2102
   initContainers:
   - name: linkerd-init
-    image: cr.l5d.io/linkerd/proxy-init:latest
+    image: ghcr.io/linkerd/proxy-init:latest
     imagePullPolicy: IfNotPresent
     args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-r", "9090", "-r", "9099"]
     securityContext:
@@ -222,7 +222,7 @@ metadata:
 spec:
   containers:
   - name: proxy-stub
-    image: cr.l5d.io/linkerd/iptables-tester:v1
+    image: ghcr.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "8080"
@@ -236,7 +236,7 @@ spec:
       privileged: false
       runAsUser: 2102
   - name: other-container
-    image: cr.l5d.io/linkerd/iptables-tester:v1
+    image: ghcr.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "9090"
@@ -245,7 +245,7 @@ spec:
     - name: http
       containerPort: 9090
   - name: blacklisted-container
-    image: cr.l5d.io/linkerd/iptables-tester:v1
+    image: ghcr.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "7070"
@@ -255,7 +255,7 @@ spec:
       containerPort: 7070
   initContainers:
   - name: linkerd-init
-    image: cr.l5d.io/linkerd/proxy-init:latest
+    image: ghcr.io/linkerd/proxy-init:latest
     imagePullPolicy: IfNotPresent
     args: ["-p", "8080",  "-o", "8080", "-u", "2102", "--inbound-ports-to-ignore", "6000-8000"]
     securityContext:
@@ -284,7 +284,7 @@ metadata:
 spec:
   containers:
   - name: proxy-stub
-    image: cr.l5d.io/linkerd/iptables-tester:v1
+    image: ghcr.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "8080"
@@ -298,7 +298,7 @@ spec:
       privileged: false
       runAsUser: 2102
   - name: other-container
-    image: cr.l5d.io/linkerd/iptables-tester:v1
+    image: ghcr.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "9090"
@@ -308,7 +308,7 @@ spec:
       containerPort: 9090
   initContainers:
   - name: linkerd-init
-    image: cr.l5d.io/linkerd/proxy-init:latest
+    image: ghcr.io/linkerd/proxy-init:latest
     imagePullPolicy: IfNotPresent
     args: ["-p", "8080",  "-o", "8080", "-u", "2102", "--subnets-to-ignore", "0.0.0.0/0"]
     securityContext:

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -68,7 +68,7 @@ spec:
     spec:
       containers:
       - name: tester
-        image: cr.l5d.io/linkerd/iptables-tester:v1
+        image: ghcr.io/linkerd/iptables-tester:v1
         env:
           - name: POD_REDIRECTS_ALL_PORTS_IP
             value: ${POD_REDIRECTS_ALL_PORTS_IP}

--- a/justfile
+++ b/justfile
@@ -4,10 +4,15 @@
 # Config
 #
 
-registry := "cr.l5d.io/linkerd"
-docker_repo := registry + "/proxy-init"
+# If DOCKER_REGISTRY is not already set, use a bogus registry with a unique
+# domain name so that it's virtually impossible to accidentally use an older
+# cached image.
+_test-id := `tr -dc 'a-z0-9' </dev/urandom | fold -w 5 | head -n 1`
+export DOCKER_REGISTRY := env_var_or_default("DOCKER_REGISTRY", "test-" + _test-id + ".local/linkerd")
+
+docker_repo := '${DOCKER_REGISTRY}' + "/proxy-init"
 docker_tag := docker_repo + ":" + "latest"
-docker_tester_tag := registry + "/iptables-tester:v1"
+docker_tester_tag := '${DOCKER_REGISTRY}' + "/iptables-tester:v1"
 dockerfile_tester_path := "./integration_test/iptables/Dockerfile-tester"
 amd64_arch := "linux/amd64"
 docker_cache_path := env_var_or_default("DOCKER_BUILDKIT_CACHE", "")

--- a/justfile
+++ b/justfile
@@ -76,6 +76,6 @@ docker-cache-prune:
       name=$(basename "$file")
       if [[ ! "${files[@]}" =~ ${name} ]]; then
     	printf 'pruned from cache: %s\n' "$file"
-    		rm -f "$file"
+    	rm -f "$file"
       fi
     done

--- a/justfile
+++ b/justfile
@@ -1,6 +1,5 @@
 # vim: set ft=make :
 # See https://just.systems/man/en
-
 #
 # Config
 #
@@ -8,9 +7,10 @@
 registry := "cr.l5d.io/linkerd"
 docker_repo := registry + "/proxy-init"
 docker_tag := docker_repo + ":" + "latest"
-docker_tester_tag := registry + "/iptables-tester:v1" 
+docker_tester_tag := registry + "/iptables-tester:v1"
 dockerfile_tester_path := "./integration_test/iptables/Dockerfile-tester"
 amd64_arch := "linux/amd64"
+docker_cache_path := env_var_or_default("DOCKER_BUILDKIT_CACHE", "")
 
 #
 # Recipes
@@ -34,29 +34,48 @@ test-unit:
 
 # Run integration tests
 test-integration cluster='init-test':
-    k3d image import -c {{cluster}} {{docker_tester_tag}} {{docker_tag}}
+    k3d image import -c {{ cluster }} {{ docker_tester_tag }} {{ docker_tag }}
     cd integration_test && ./run_tests.sh
 
 # Run all tests in a k3d cluster
 test:
-	#!/usr/bin/env bash
-	set -eu
-	just test-unit
-	just docker-proxy-init
-	just docker-tester
-	just test-integration
+    #!/usr/bin/env bash
+    set -eu
+    just test-unit
+    just docker-proxy-init
+    just docker-tester
+    just test-integration
 
 # Build docker image for proxy-init (Development)
 docker-proxy-init arch=amd64_arch:
-	docker buildx build . \
-		--tag={{docker_tag}} \
-		--platform={{arch}} \
-		--load \
+    docker buildx build . \
+    	--tag={{ docker_tag }} \
+    	--platform={{ arch }} \
+    	--load \
 
 # Build docker image for iptables-tester (Development)
 docker-tester arch=amd64_arch:
-	docker buildx build ./integration_test \
-		--file={{dockerfile_tester_path}} \
-		--tag={{docker_tester_tag}} \
-		--platform={{arch}} \
-		--load
+    docker buildx build ./integration_test \
+    	--file={{ dockerfile_tester_path }} \
+    	--tag={{ docker_tester_tag }} \
+    	--platform={{ arch }} \
+    	--load
+
+# Prune Docker BuildKit cache
+docker-cache-prune:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+   
+    # Deletes all files under the buildkit blob directory that are not referred
+    # to any longer in the cache manifest file
+    manifest_sha=$(jq -r .manifests[0].digest < "{{ docker_cache_path }}/index.json")
+    manifest=${manifest_sha#"sha256:"}
+    files=("$manifest")
+    while IFS= read -r line; do files+=("$line"); done <<< "$(jq -r '.manifests[].digest | sub("^sha256:"; "")' < "{{ docker_cache_path }}/blobs/sha256/$manifest")"
+    for file in "{{ docker_cache_path }}"/blobs/sha256/*; do
+      name=$(basename "$file")
+      if [[ ! "${files[@]}" =~ ${name} ]]; then
+    	printf 'pruned from cache: %s\n' "$file"
+    		rm -f "$file"
+      fi
+    done


### PR DESCRIPTION
In the release workflow, we're calling an inexistent
'bin/docker-prune-cache' script. The script will delete all lingering
files in the cache that are no longer in use or referenced by the cache
manifest file (thereby cleaning up storage).

This change extracts the logic from the script (present in the linkerd2
repo) and adds it as a justfile recipe, to be called in the release
workflow.

This change also formats the justfile through `just --fmt`

Signed-off-by: Matei David <matei@buoyant.io>