### PR TITLE
dev: Add a devcontainer, update dependabot

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+    "name": "linkerd2",
+    "image": "ghcr.io/linkerd/dev:v21",
+    "extensions": [
+        "DavidAnson.vscode-markdownlint",
+        "golang.go",
+        "kokakiwi.vscode-just",
+        "NathanRidley.autotrim",
+        "samverschueren.final-newline",
+        "tamasfe.even-better-toml",
+    ],
+    "settings": {
+        "go.lintTool": "golangci-lint"
+    },
+    "runArgs": [
+        "--init",
+        // Limit container memory usage.
+        "--memory=12g",
+        "--memory-swap=12g",
+        // Use the host network so we can access k3d, etc.
+        "--net=host",
+    ],
+    "overrideCommand": false,
+    "remoteUser": "code",
+    "mounts": [
+        "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
+    ]
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This change adds a devcontainer configuration that uses the main repo's
dev image. It also updates dependabot to update the base docker image.

Signed-off-by: Oliver Gould <ver@buoyant.io>