### PR TITLE
dev: Update tester to Go 1.18

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,7 @@ on:
       - '**/*.go'
       - Dockerfile
       - go.sum
+      - integration_test/**
       - justfile
 
 jobs:

--- a/integration_test/iptables/Dockerfile-tester
+++ b/integration_test/iptables/Dockerfile-tester
@@ -1,7 +1,7 @@
-FROM golang:1.19.0
-
-ADD iptables/ /go
-# Kubernetes Jobs will be retried until they return status 0,
-# so we need to output the status for processing but make sure
-# that the container exits with 0
-ENTRYPOINT cd /go && (go test -v -integration-tests; echo "status:$?")
+FROM golang:1.18.5
+ENV GOCACHE=/tmp/
+WORKDIR /src
+COPY integration_test/iptables/http_test.go /src/
+COPY integration_test/iptables/test_service /src/test_service
+COPY go.mod go.sum /src
+RUN go mod tidy

--- a/integration_test/iptables/iptablestest-lab.yaml
+++ b/integration_test/iptables/iptablestest-lab.yaml
@@ -9,20 +9,20 @@ metadata:
 spec:
   containers:
   - name: webserver
-    image: ghcr.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "8080"
-    command: ["go", "run", "/go/test_service/test_service.go"]
+    command: ["go", "run", "./test_service/test_service.go"]
     ports:
     - name: http
       containerPort: 8080
   - name: other-container
-    image: ghcr.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "9090"
-    command: ["go", "run", "/go/test_service/test_service.go"]
+    command: ["go", "run", "./test_service/test_service.go"]
     ports:
     - name: http
       containerPort: 9090
@@ -49,20 +49,20 @@ metadata:
 spec:
   containers:
   - name: webserver
-    image: ghcr.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "8080"
-    command: ["go", "run", "/go/test_service/test_service.go"]
+    command: ["go", "run", "./test_service/test_service.go"]
     ports:
     - name: http
       containerPort: 8080
   - name: other-container
-    image: ghcr.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "9090"
-    command: ["go", "run", "/go/test_service/test_service.go"]
+    command: ["go", "run", "./test_service/test_service.go"]
     ports:
     - name: http
       containerPort: 9090
@@ -71,7 +71,7 @@ spec:
   # iptable rules are run more than once. The linkerd-init container
   # should log "Found existing firewall configuration..."
   - name: iptables-test
-    image: ghcr.io/linkerd/proxy-init:latest
+    image: test.l5d.io/linkerd/proxy-init:latest
     imagePullPolicy: IfNotPresent
     args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
     securityContext:
@@ -88,7 +88,7 @@ spec:
     - mountPath: /run
       name: linkerd-proxy-init-xtables-lock
   - name: linkerd-init
-    image: ghcr.io/linkerd/proxy-init:latest
+    image: test.l5d.io/linkerd/proxy-init:latest
     imagePullPolicy: IfNotPresent
     args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
     securityContext:
@@ -118,22 +118,22 @@ metadata:
 spec:
   containers:
   - name: other-container
-    image: ghcr.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "9090"
-    command: ["go", "run", "/go/test_service/test_service.go"]
+    command: ["go", "run", "./test_service/test_service.go"]
     ports:
     - name: http
       containerPort: 9090
   - name: proxy-stub
-    image: ghcr.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "8080"
     - name: AM_I_THE_PROXY
       value: "yes"
-    command: ["go", "run", "/go/test_service/test_service.go"]
+    command: ["go", "run", "./test_service/test_service.go"]
     securityContext:
       privileged: false
       runAsUser: 2102
@@ -142,7 +142,7 @@ spec:
       containerPort: 8080
   initContainers:
   - name: linkerd-init
-    image: ghcr.io/linkerd/proxy-init:latest
+    image: test.l5d.io/linkerd/proxy-init:latest
     imagePullPolicy: IfNotPresent
     args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
     securityContext:
@@ -184,13 +184,13 @@ metadata:
 spec:
   containers:
   - name: proxy-stub
-    image: ghcr.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "8080"
     - name: AM_I_THE_PROXY
       value: "yes"
-    command: ["go", "run", "/go/test_service/test_service.go"]
+    command: ["go", "run", "./test_service/test_service.go"]
     ports:
     - name: http
       containerPort: 8080
@@ -199,7 +199,7 @@ spec:
       runAsUser: 2102
   initContainers:
   - name: linkerd-init
-    image: ghcr.io/linkerd/proxy-init:latest
+    image: test.l5d.io/linkerd/proxy-init:latest
     imagePullPolicy: IfNotPresent
     args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-r", "9090", "-r", "9099"]
     securityContext:
@@ -229,13 +229,13 @@ metadata:
 spec:
   containers:
   - name: proxy-stub
-    image: ghcr.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "8080"
     - name: AM_I_THE_PROXY
       value: "yes"
-    command: ["go", "run", "/go/test_service/test_service.go"]
+    command: ["go", "run", "./test_service/test_service.go"]
     ports:
     - name: http
       containerPort: 8080
@@ -243,26 +243,26 @@ spec:
       privileged: false
       runAsUser: 2102
   - name: other-container
-    image: ghcr.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "9090"
-    command: ["go", "run", "/go/test_service/test_service.go"]
+    command: ["go", "run", "./test_service/test_service.go"]
     ports:
     - name: http
       containerPort: 9090
   - name: blacklisted-container
-    image: ghcr.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "7070"
-    command: ["go", "run", "/go/test_service/test_service.go"]
+    command: ["go", "run", "./test_service/test_service.go"]
     ports:
     - name: http
       containerPort: 7070
   initContainers:
   - name: linkerd-init
-    image: ghcr.io/linkerd/proxy-init:latest
+    image: test.l5d.io/linkerd/proxy-init:latest
     imagePullPolicy: IfNotPresent
     args: ["-p", "8080",  "-o", "8080", "-u", "2102", "--inbound-ports-to-ignore", "6000-8000"]
     securityContext:
@@ -292,13 +292,13 @@ metadata:
 spec:
   containers:
   - name: proxy-stub
-    image: ghcr.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "8080"
     - name: AM_I_THE_PROXY
       value: "yes"
-    command: ["go", "run", "/go/test_service/test_service.go"]
+    command: ["go", "run", "./test_service/test_service.go"]
     ports:
     - name: http
       containerPort: 8080
@@ -306,17 +306,17 @@ spec:
       privileged: false
       runAsUser: 2102
   - name: other-container
-    image: ghcr.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:v1
     env:
     - name: PORT
       value: "9090"
-    command: ["go", "run", "/go/test_service/test_service.go"]
+    command: ["go", "run", "./test_service/test_service.go"]
     ports:
     - name: http
       containerPort: 9090
   initContainers:
   - name: linkerd-init
-    image: ghcr.io/linkerd/proxy-init:latest
+    image: test.l5d.io/linkerd/proxy-init:latest
     imagePullPolicy: IfNotPresent
     args: ["-p", "8080",  "-o", "8080", "-u", "2102", "--subnets-to-ignore", "0.0.0.0/0"]
     securityContext:

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euxo pipefail
 
 cd "${BASH_SOURCE[0]%/*}"
 
@@ -52,7 +52,7 @@ POD_IGNORES_SUBNETS_IP=$(kip pod-ignores-subnets)
 echo "POD_IGNORES_SUBNETS_IP=${POD_IGNORES_SUBNETS_IP}"
 
 echo '# Running tester...'
-output=$(k run iptables-tester \
+k run iptables-tester \
         --attach \
         --command \
         --env=POD_IGNORES_SUBNETS_IP="${POD_IGNORES_SUBNETS_IP}" \
@@ -61,16 +61,13 @@ output=$(k run iptables-tester \
         --env=POD_DOESNT_REDIRECT_BLACKLISTED_IP="${POD_DOESNT_REDIRECT_BLACKLISTED_IP}" \
         --env=POD_WITH_EXISTING_RULES_IP="${POD_WITH_EXISTING_RULES_IP}" \
         --env=POD_WITH_NO_RULES_IP="${POD_WITH_NO_RULES_IP}" \
-        --image=ghcr.io/linkerd/iptables-tester:v1 \
+        --image=test.l5d.io/linkerd/iptables-tester:v1 \
         --image-pull-policy=Never \
         --namespace=proxy-init-test \
         --quiet \
         --restart=Never \
-        --rm)
-echo "$output"
-if ! [[ "$output" =~ status:0 ]]; then
-  echo 'Failed' >&2
-  exit 1
-fi
+        --rm \
+        -- \
+        go test -v -integration-tests
 
 k delete ns proxy-init-test

--- a/justfile
+++ b/justfile
@@ -4,8 +4,8 @@
 # Config
 #
 
-_image := "ghcr.io/linkerd/proxy-init:latest"
-_test-image := "ghcr.io/linkerd/iptables-tester:v1"
+_image := "test.l5d.io/linkerd/proxy-init:latest"
+_test-image := "test.l5d.io/linkerd/iptables-tester:v1"
 docker-arch := "linux/amd64"
 
 #
@@ -51,7 +51,7 @@ docker-proxy-init:
 
 # Build docker image for iptables-tester (Development)
 docker-tester:
-    docker buildx build integration_test \
+    docker buildx build . \
     	--file=integration_test/iptables/Dockerfile-tester \
     	--tag={{ _test-image }} \
     	--platform={{ docker-arch }} \


### PR DESCRIPTION
* Update tester container to use Go 1.18
* Simplify test runner to stop matching output
* Use a fake container registry, `test.l5d.io` to prevent confusion with
  the public registries.

Signed-off-by: Oliver Gould <ver@buoyant.io>