### PR TITLE
dev: Never pull images during tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM --platform=$BUILDPLATFORM golang:1.18.2-alpine3.14 as golang
+FROM --platform=$BUILDPLATFORM golang:1.18-alpine as golang
 WORKDIR /build
 
 # cache dependencies

--- a/integration_test/iptables/Dockerfile-tester
+++ b/integration_test/iptables/Dockerfile-tester
@@ -1,4 +1,4 @@
-FROM golang:1.18.5
+FROM golang:1.18
 ENV GOCACHE=/tmp/
 WORKDIR /src
 COPY integration_test/iptables/http_test.go /src/

--- a/integration_test/iptables/iptablestest-lab.yaml
+++ b/integration_test/iptables/iptablestest-lab.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   containers:
   - name: webserver
-    image: test.l5d.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:test
+    imagePullPolicy: Never
     env:
     - name: PORT
       value: "8080"
@@ -18,7 +19,8 @@ spec:
     - name: http
       containerPort: 8080
   - name: other-container
-    image: test.l5d.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:test
+    imagePullPolicy: Never
     env:
     - name: PORT
       value: "9090"
@@ -49,7 +51,8 @@ metadata:
 spec:
   containers:
   - name: webserver
-    image: test.l5d.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:test
+    imagePullPolicy: Never
     env:
     - name: PORT
       value: "8080"
@@ -58,7 +61,8 @@ spec:
     - name: http
       containerPort: 8080
   - name: other-container
-    image: test.l5d.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:test
+    imagePullPolicy: Never
     env:
     - name: PORT
       value: "9090"
@@ -71,8 +75,8 @@ spec:
   # iptable rules are run more than once. The linkerd-init container
   # should log "Found existing firewall configuration..."
   - name: iptables-test
-    image: test.l5d.io/linkerd/proxy-init:latest
-    imagePullPolicy: IfNotPresent
+    image: test.l5d.io/linkerd/proxy-init:test
+    imagePullPolicy: Never
     args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
     securityContext:
       allowPrivilegeEscalation: false
@@ -88,8 +92,8 @@ spec:
     - mountPath: /run
       name: linkerd-proxy-init-xtables-lock
   - name: linkerd-init
-    image: test.l5d.io/linkerd/proxy-init:latest
-    imagePullPolicy: IfNotPresent
+    image: test.l5d.io/linkerd/proxy-init:test
+    imagePullPolicy: Never
     args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
     securityContext:
       allowPrivilegeEscalation: false
@@ -118,7 +122,8 @@ metadata:
 spec:
   containers:
   - name: other-container
-    image: test.l5d.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:test
+    imagePullPolicy: Never
     env:
     - name: PORT
       value: "9090"
@@ -127,7 +132,8 @@ spec:
     - name: http
       containerPort: 9090
   - name: proxy-stub
-    image: test.l5d.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:test
+    imagePullPolicy: Never
     env:
     - name: PORT
       value: "8080"
@@ -142,8 +148,8 @@ spec:
       containerPort: 8080
   initContainers:
   - name: linkerd-init
-    image: test.l5d.io/linkerd/proxy-init:latest
-    imagePullPolicy: IfNotPresent
+    image: test.l5d.io/linkerd/proxy-init:test
+    imagePullPolicy: Never
     args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
     securityContext:
       allowPrivilegeEscalation: false
@@ -184,7 +190,8 @@ metadata:
 spec:
   containers:
   - name: proxy-stub
-    image: test.l5d.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:test
+    imagePullPolicy: Never
     env:
     - name: PORT
       value: "8080"
@@ -199,8 +206,8 @@ spec:
       runAsUser: 2102
   initContainers:
   - name: linkerd-init
-    image: test.l5d.io/linkerd/proxy-init:latest
-    imagePullPolicy: IfNotPresent
+    image: test.l5d.io/linkerd/proxy-init:test
+    imagePullPolicy: Never
     args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-r", "9090", "-r", "9099"]
     securityContext:
       allowPrivilegeEscalation: false
@@ -229,7 +236,8 @@ metadata:
 spec:
   containers:
   - name: proxy-stub
-    image: test.l5d.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:test
+    imagePullPolicy: Never
     env:
     - name: PORT
       value: "8080"
@@ -243,7 +251,8 @@ spec:
       privileged: false
       runAsUser: 2102
   - name: other-container
-    image: test.l5d.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:test
+    imagePullPolicy: Never
     env:
     - name: PORT
       value: "9090"
@@ -252,7 +261,8 @@ spec:
     - name: http
       containerPort: 9090
   - name: blacklisted-container
-    image: test.l5d.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:test
+    imagePullPolicy: Never
     env:
     - name: PORT
       value: "7070"
@@ -262,8 +272,8 @@ spec:
       containerPort: 7070
   initContainers:
   - name: linkerd-init
-    image: test.l5d.io/linkerd/proxy-init:latest
-    imagePullPolicy: IfNotPresent
+    image: test.l5d.io/linkerd/proxy-init:test
+    imagePullPolicy: Never
     args: ["-p", "8080",  "-o", "8080", "-u", "2102", "--inbound-ports-to-ignore", "6000-8000"]
     securityContext:
       allowPrivilegeEscalation: false
@@ -292,7 +302,8 @@ metadata:
 spec:
   containers:
   - name: proxy-stub
-    image: test.l5d.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:test
+    imagePullPolicy: Never
     env:
     - name: PORT
       value: "8080"
@@ -306,7 +317,8 @@ spec:
       privileged: false
       runAsUser: 2102
   - name: other-container
-    image: test.l5d.io/linkerd/iptables-tester:v1
+    image: test.l5d.io/linkerd/iptables-tester:test
+    imagePullPolicy: Never
     env:
     - name: PORT
       value: "9090"
@@ -316,8 +328,8 @@ spec:
       containerPort: 9090
   initContainers:
   - name: linkerd-init
-    image: test.l5d.io/linkerd/proxy-init:latest
-    imagePullPolicy: IfNotPresent
+    image: test.l5d.io/linkerd/proxy-init:test
+    imagePullPolicy: Never
     args: ["-p", "8080",  "-o", "8080", "-u", "2102", "--subnets-to-ignore", "0.0.0.0/0"]
     securityContext:
       allowPrivilegeEscalation: false

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -61,7 +61,7 @@ k run iptables-tester \
         --env=POD_DOESNT_REDIRECT_BLACKLISTED_IP="${POD_DOESNT_REDIRECT_BLACKLISTED_IP}" \
         --env=POD_WITH_EXISTING_RULES_IP="${POD_WITH_EXISTING_RULES_IP}" \
         --env=POD_WITH_NO_RULES_IP="${POD_WITH_NO_RULES_IP}" \
-        --image=test.l5d.io/linkerd/iptables-tester:v1 \
+        --image=test.l5d.io/linkerd/iptables-tester:test \
         --image-pull-policy=Never \
         --namespace=proxy-init-test \
         --quiet \

--- a/justfile
+++ b/justfile
@@ -4,8 +4,8 @@
 # Config
 #
 
-_image := "test.l5d.io/linkerd/proxy-init:latest"
-_test-image := "test.l5d.io/linkerd/iptables-tester:v1"
+_image := "test.l5d.io/linkerd/proxy-init:test"
+_test-image := "test.l5d.io/linkerd/iptables-tester:test"
 docker-arch := "linux/amd64"
 
 #


### PR DESCRIPTION
We use pre-loaded images in integration tests, so we should never try to
fetch them from a registry. This change updates image to use a `test`
tag. It also simplifies base image tags to be less specific (for
intermediate stages).

Signed-off-by: Oliver Gould <ver@buoyant.io>