### PR TITLE
dev: Set a timeout when testing failed connections

### DIFF
--- a/integration_test/iptables/http_test.go
+++ b/integration_test/iptables/http_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 const (
@@ -211,8 +212,10 @@ func makeCallFromContainerToAnother(t *testing.T, fromPodNamed string, fromConta
 
 func expectCannotConnectGetRequestTo(t *testing.T, host string, port string) {
 	targetURL := fmt.Sprintf("http://%s:%s/", host, port)
-	fmt.Printf("Expecting failed GET to %s\n", targetURL)
-	resp, err := http.Get(targetURL)
+	c := &http.Client{
+		Timeout: time.Second * 3,
+	}
+	resp, err := c.Get(targetURL)
 	if err == nil {
 		t.Fatalf("Expected error when connecting to %s, got:\n%+v", targetURL, resp)
 	}


### PR DESCRIPTION
Our tests that expect connections to fail wait the default 30s for each
request to timeout, which adds unnecessary slowness when running tests
(as tests take 90s to complete 3 failed requests).

This change reduces the timeout to 3s so that tests complete in under
10s.

Signed-off-by: Oliver Gould <ver@buoyant.io>