### PR TITLE
Cleanup integration test helpers

### DIFF
--- a/integration_test/iptables/http_test.go
+++ b/integration_test/iptables/http_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -33,102 +34,113 @@ func TestMain(m *testing.M) {
 func TestPodWithNoRules(t *testing.T) {
 	t.Parallel()
 
-	podWithNoRulesIP := os.Getenv("POD_WITH_NO_RULES_IP")
 	svcName := "svc-pod-with-no-rules"
+	podIP := os.Getenv("POD_WITH_NO_RULES_IP")
+	if podIP == "" {
+		t.Skipf("POD_WITH_NO_RULES_IP is not set")
+	}
 
 	t.Run("succeeds connecting to pod directly through container's exposed port", func(t *testing.T) {
-		expectSuccessfulGetRequestTo(t, podWithNoRulesIP, proxyContainerPort)
+		expectSuccessfulGetRequest(t, makeURL(podIP, proxyContainerPort))
 	})
 
 	t.Run("fails to connect to pod directly through any port that isn't the container's exposed port", func(t *testing.T) {
-		expectCannotConnectGetRequestTo(t, podWithNoRulesIP, "8088")
-		expectCannotConnectGetRequestTo(t, podWithNoRulesIP, "8888")
-		expectCannotConnectGetRequestTo(t, podWithNoRulesIP, "8988")
+		for _, port := range []string{"8088", "8888", "8988"} {
+			expectCannotConnectGetRequest(t, makeURL(podIP, port))
+		}
 	})
 
 	t.Run("succeeds connecting to pod via a service through container's exposed port", func(t *testing.T) {
-		expectSuccessfulGetRequestTo(t, svcName, proxyContainerPort)
+		expectSuccessfulGetRequest(t, makeURL(svcName, proxyContainerPort))
 	})
 
 	t.Run("fails to connect to pod via a service through any port that isn't the container's exposed port", func(t *testing.T) {
-		expectCannotConnectGetRequestTo(t, svcName, "8088")
-		expectCannotConnectGetRequestTo(t, svcName, "8888")
-		expectCannotConnectGetRequestTo(t, svcName, "8988")
+		for _, port := range []string{"8088", "8888", "8988"} {
+			expectCannotConnectGetRequest(t, makeURL(svcName, port))
+		}
 	})
 }
 
 func TestPodRedirectsAllPorts(t *testing.T) {
 	t.Parallel()
 
-	podRedirectsAllPortsIP := os.Getenv("POD_REDIRECTS_ALL_PORTS_IP")
 	svcName := "svc-pod-redirects-all-ports"
+	podIP := os.Getenv("POD_REDIRECTS_ALL_PORTS_IP")
+	if podIP == "" {
+		t.Skipf("POD_REDIRECTS_ALL_PORTS_IP is not set")
+	}
 
 	t.Run("succeeds connecting to pod directly through container's exposed port", func(t *testing.T) {
-		expectSuccessfulGetRequestTo(t, podRedirectsAllPortsIP, proxyContainerPort)
+		expectSuccessfulGetRequest(t, makeURL(podIP, proxyContainerPort))
 	})
 
 	t.Run("succeeds connecting to pod directly through any port that isn't the container's exposed port", func(t *testing.T) {
-		expectSuccessfulGetRequestTo(t, podRedirectsAllPortsIP, "8088")
-		expectSuccessfulGetRequestTo(t, podRedirectsAllPortsIP, "8888")
-		expectSuccessfulGetRequestTo(t, podRedirectsAllPortsIP, "8988")
-
+		for _, port := range []string{"8088", "8888", "8988"} {
+			expectSuccessfulGetRequest(t, makeURL(podIP, port))
+		}
 	})
 
 	t.Run("succeeds connecting to pod via a service through container's exposed port", func(t *testing.T) {
-		expectSuccessfulGetRequestTo(t, svcName, proxyContainerPort)
+		expectSuccessfulGetRequest(t, makeURL(svcName, proxyContainerPort))
 	})
 
 	t.Run("fails to connect to pod via a service through any port that isn't the container's exposed port", func(t *testing.T) {
-		expectCannotConnectGetRequestTo(t, svcName, "8088")
-		expectCannotConnectGetRequestTo(t, svcName, "8888")
-		expectCannotConnectGetRequestTo(t, svcName, "8988")
+		for _, port := range []string{"8088", "8888", "8988"} {
+			expectCannotConnectGetRequest(t, makeURL(svcName, port))
+		}
 	})
 }
 
 func TestPodWithSomePortsRedirected(t *testing.T) {
 	t.Parallel()
 
-	podRedirectsSomePortsIP := os.Getenv("POD_REDIRECTS_WHITELISTED_IP")
+	podIP := os.Getenv("POD_REDIRECTS_WHITELISTED_IP")
+	if podIP == "" {
+		t.Skipf("POD_REDIRECTS_WHITELISTED_IP is not set")
+	}
 
 	t.Run("succeeds connecting to pod directly through container's exposed port", func(t *testing.T) {
-		expectSuccessfulGetRequestTo(t, podRedirectsSomePortsIP, proxyContainerPort)
+		expectSuccessfulGetRequest(t, makeURL(podIP, proxyContainerPort))
 	})
 
 	t.Run("succeeds connecting to pod directly through ports configured to redirect", func(t *testing.T) {
-		expectSuccessfulGetRequestTo(t, podRedirectsSomePortsIP, "9090")
-		expectSuccessfulGetRequestTo(t, podRedirectsSomePortsIP, "9099")
+		for _, port := range []string{"9090", "9099"} {
+			expectSuccessfulGetRequest(t, makeURL(podIP, port))
+		}
 	})
 
 	t.Run("fails to connect to pod via through any port that isn't configured to redirect", func(t *testing.T) {
-		expectCannotConnectGetRequestTo(t, podRedirectsSomePortsIP, "8088")
-		expectCannotConnectGetRequestTo(t, podRedirectsSomePortsIP, "8888")
-		expectCannotConnectGetRequestTo(t, podRedirectsSomePortsIP, "8988")
+		for _, port := range []string{"8088", "8888", "8988"} {
+			expectCannotConnectGetRequest(t, makeURL(podIP, port))
+		}
 	})
 }
 
 func TestPodWithSomePortsIgnored(t *testing.T) {
 	t.Parallel()
 
-	podIgnoredSomePortsIP := os.Getenv("POD_DOESNT_REDIRECT_BLACKLISTED_IP")
+	podIP := os.Getenv("POD_DOESNT_REDIRECT_BLACKLISTED_IP")
+	if podIP == "" {
+		t.Skipf("POD_DOESNT_REDIRECT_BLACKLISTED_IP is not set")
+	}
 
 	t.Run("succeeds connecting to pod directly through container's exposed port", func(t *testing.T) {
-		expectSuccessfulGetRequestTo(t, podIgnoredSomePortsIP, proxyContainerPort)
+		expectSuccessfulGetRequest(t, makeURL(podIP, proxyContainerPort))
 	})
 
 	t.Run("succeeds connecting to pod directly through ports configured to redirect", func(t *testing.T) {
-		expectSuccessfulGetRequestTo(t, podIgnoredSomePortsIP, "9090")
-		expectSuccessfulGetRequestTo(t, podIgnoredSomePortsIP, "9099")
+		for _, port := range []string{"9090", "9099"} {
+			expectSuccessfulGetRequest(t, makeURL(podIP, port))
+		}
 	})
 
 	t.Run("doesnt redirect when through port that is ignored", func(t *testing.T) {
-		response := expectSuccessfulGetRequestTo(t, podIgnoredSomePortsIP, ignoredContainerPort)
-
-		if response == "proxy" {
-			t.Fatalf("Expected connection through ignored port to directly hit service, but hit [%s]", response)
+		rsp := expectSuccessfulGetRequest(t, makeURL(podIP, ignoredContainerPort))
+		if rsp == "proxy" {
+			t.Fatalf("Expected connection through ignored port to directly hit service, but hit [%s]", rsp)
 		}
-
-		if !strings.Contains(response, ignoredContainerPort) {
-			t.Fatalf("Expected to be able to connect to %s without redirects, but got back %s", ignoredContainerPort, response)
+		if !strings.Contains(rsp, ignoredContainerPort) {
+			t.Fatalf("Expected to be able to connect to %s without redirects, but got back %s", ignoredContainerPort, rsp)
 		}
 	})
 }
@@ -136,44 +148,39 @@ func TestPodWithSomePortsIgnored(t *testing.T) {
 func TestPodMakesOutboundConnection(t *testing.T) {
 	t.Parallel()
 
-	podIgnoredSomePortsIP := os.Getenv("POD_DOESNT_REDIRECT_BLACKLISTED_IP")
-	podWithNoRulesIP := os.Getenv("POD_WITH_NO_RULES_IP")
-	podWithNoRulesName := "pod-with-no-rules"
-
 	proxyPodName := "pod-doesnt-redirect-blacklisted"
-	proxyPodIP := podIgnoredSomePortsIP
+	proxyPodIP := os.Getenv("POD_DOESNT_REDIRECT_BLACKLISTED_IP")
+	if proxyPodIP == "" {
+		t.Skipf("POD_DOESNT_REDIRECT_BLACKLISTED_IP is not set")
+	}
+
+	targetPodName := "pod-with-no-rules"
+	targetPodIP := os.Getenv("POD_WITH_NO_RULES_IP")
+	if targetPodIP == "" {
+		t.Skipf("POD_WITH_NO_RULES_IP is not set")
+	}
 
 	t.Run("connecting to another pod from non-proxy container gets redirected to proxy", func(t *testing.T) {
-		portOfContainerToMAkeTheRequest := ignoredContainerPort
-		targetPodIP := podWithNoRulesIP
-		targetPort := ignoredContainerPort
-
-		response := makeCallFromContainerToAnother(t, proxyPodIP, portOfContainerToMAkeTheRequest, targetPodIP, targetPort)
-
-		expectedDownstreamResponse := fmt.Sprintf("me:[%s:%s]downstream:[proxy]", proxyPodName, portOfContainerToMAkeTheRequest)
-		if !strings.Contains(response, expectedDownstreamResponse) {
-			t.Fatalf("Expected response to be redirected to the proxy, expected %s but it was %s", expectedDownstreamResponse, response)
+		rsp := makeCallFromContainerToAnother(t, proxyPodIP, ignoredContainerPort, targetPodIP, ignoredContainerPort)
+		expected := fmt.Sprintf("me:[%s:%s]downstream:[proxy]", proxyPodName, ignoredContainerPort)
+		if !strings.Contains(rsp, expected) {
+			t.Fatalf("Expected response to be redirected to the proxy, expected %s but it was %s", expected, rsp)
 		}
 	})
 
 	t.Run("connecting to another pod from proxy container does not get redirected to proxy", func(t *testing.T) {
-		targetPodName := podWithNoRulesName
-		targetPodIP := podWithNoRulesIP
-
-		response := makeCallFromContainerToAnother(t, proxyPodIP, proxyContainerPort, targetPodIP, notTheProxyContainerPort)
-
-		expectedDownstreamResponse := fmt.Sprintf("me:[proxy]downstream:[%s:%s]", targetPodName, notTheProxyContainerPort)
-		if !strings.Contains(response, expectedDownstreamResponse) {
-			t.Fatalf("Expected response not to be redirected to the proxy, expected %s but it was %s", expectedDownstreamResponse, response)
+		rsp := makeCallFromContainerToAnother(t, proxyPodIP, proxyContainerPort, targetPodIP, notTheProxyContainerPort)
+		expected := fmt.Sprintf("me:[proxy]downstream:[%s:%s]", targetPodName, notTheProxyContainerPort)
+		if !strings.Contains(rsp, expected) {
+			t.Fatalf("Expected response not to be redirected to the proxy, expected %s but it was %s", expected, rsp)
 		}
 	})
 
 	t.Run("connecting to loopback from non-proxy container does not get redirected to proxy", func(t *testing.T) {
-		response := makeCallFromContainerToAnother(t, proxyPodIP, ignoredContainerPort, "127.0.0.1", notTheProxyContainerPort)
-
-		expectedDownstreamResponse := fmt.Sprintf("me:[%s:%s]downstream:[%s:%s]", proxyPodName, ignoredContainerPort, proxyPodName, notTheProxyContainerPort)
-		if !strings.Contains(response, expectedDownstreamResponse) {
-			t.Fatalf("Expected response not to be redirected to the proxy, expected %s but it was %s", expectedDownstreamResponse, response)
+		rsp := makeCallFromContainerToAnother(t, proxyPodIP, ignoredContainerPort, "127.0.0.1", notTheProxyContainerPort)
+		expected := fmt.Sprintf("me:[%s:%s]downstream:[%s:%s]", proxyPodName, ignoredContainerPort, proxyPodName, notTheProxyContainerPort)
+		if !strings.Contains(rsp, expected) {
+			t.Fatalf("Expected response not to be redirected to the proxy, expected %s but it was %s", expected, rsp)
 		}
 	})
 }
@@ -181,55 +188,65 @@ func TestPodMakesOutboundConnection(t *testing.T) {
 func TestPodWithSomeSubnetsIgnored(t *testing.T) {
 	t.Parallel()
 
-	podIgnoredSomeSubnetsIP := os.Getenv("POD_IGNORES_SUBNETS_IP")
+	podIP := os.Getenv("POD_IGNORES_SUBNETS_IP")
+	if podIP == "" {
+		t.Skipf("POD_IGNORES_SUBNETS_IP is not set")
+	}
 
 	t.Run("connecting to a not-a-proxy-container should bypass proxy container", func(t *testing.T) {
-		response := expectSuccessfulGetRequestTo(t, podIgnoredSomeSubnetsIP, notTheProxyContainerPort)
-
-		expectedResponse := fmt.Sprintf("pod-ignores-subnets:%s", notTheProxyContainerPort)
-		if !strings.Contains(response, expectedResponse) {
-			t.Fatalf("Expected response to be bypassed, expected %s but it was %s", expectedResponse, response)
+		rsp := expectSuccessfulGetRequest(t, makeURL(podIP, notTheProxyContainerPort))
+		expected := fmt.Sprintf("pod-ignores-subnets:%s", notTheProxyContainerPort)
+		if !strings.Contains(rsp, expected) {
+			t.Fatalf("Expected response to be bypassed, expected %s but it was %s", expected, rsp)
 		}
 	})
 
 	t.Run("connecting directly to the proxy container pod should still work", func(t *testing.T) {
-		response := expectSuccessfulGetRequestTo(t, podIgnoredSomeSubnetsIP, proxyContainerPort)
-
-		expectedResponse := "proxy"
-		if !strings.Contains(response, expectedResponse) {
-			t.Fatalf("Expected response from the proxy container, expected %s but it was %s", expectedResponse, response)
+		rsp := expectSuccessfulGetRequest(t, makeURL(podIP, proxyContainerPort))
+		expected := "proxy"
+		if !strings.Contains(rsp, expected) {
+			t.Fatalf("Expected response from the proxy container, expected %s but it was %s", expected, rsp)
 		}
 	})
 }
 
-func makeCallFromContainerToAnother(t *testing.T, fromPodNamed string, fromContainerAtPort string, podIWantToReachName string, containerPortIWantToReach string) string {
-	downstreamURL := fmt.Sprintf("http://%s:%s", podIWantToReachName, containerPortIWantToReach)
+// === Helpers ===
 
-	//Make request asking target to make a back-end request
-	targetURL := fmt.Sprintf("http://%s:%s/call?url=%s", fromPodNamed, fromContainerAtPort, url.QueryEscape(downstreamURL))
-	return expectSuccessfulGetRequestToURL(t, targetURL)
+func makeCallFromContainerToAnother(t *testing.T, viaHost, viaPort, targetHost, targetPort string) string {
+	t.Helper()
+	targetURL := makeURL(targetHost, targetPort)
+	url := fmt.Sprintf("%scall?url=%s", makeURL(viaHost, viaPort), url.QueryEscape(targetURL))
+	return expectSuccessfulGetRequest(t, url)
 }
 
-func expectCannotConnectGetRequestTo(t *testing.T, host string, port string) {
-	targetURL := fmt.Sprintf("http://%s:%s/", host, port)
-	c := &http.Client{
-		Timeout: time.Second * 3,
+func makeURL(host, port string) string {
+	return fmt.Sprintf("http://%s/", net.JoinHostPort(host, port))
+}
+
+func client() *http.Client {
+	d := &net.Dialer{
+		Timeout: 1 * time.Second,
 	}
-	resp, err := c.Get(targetURL)
+	return &http.Client{
+		Transport: &http.Transport{
+			Dial: d.Dial,
+		},
+	}
+}
+
+func expectCannotConnectGetRequest(t *testing.T, url string) {
+	t.Helper()
+	t.Logf("Expecting failed GET to %s\n", url)
+	resp, err := client().Get(url)
 	if err == nil {
-		t.Fatalf("Expected error when connecting to %s, got:\n%+v", targetURL, resp)
+		t.Fatalf("Expected error when connecting to %s, got:\n%+v", url, resp)
 	}
 }
 
-func expectSuccessfulGetRequestTo(t *testing.T, host string, port string) string {
-	targetURL := fmt.Sprintf("http://%s:%s/", host, port)
-
-	return expectSuccessfulGetRequestToURL(t, targetURL)
-}
-
-func expectSuccessfulGetRequestToURL(t *testing.T, url string) string {
-	fmt.Printf("Expecting successful GET to %s\n", url)
-	resp, err := http.Get(url)
+func expectSuccessfulGetRequest(t *testing.T, url string) string {
+	t.Helper()
+	t.Logf("Expecting successful GET to %s\n", url)
+	resp, err := client().Get(url)
 	if err != nil {
 		t.Fatalf("failed to send HTTP GET to %s:\n%v", url, err)
 	}
@@ -238,6 +255,6 @@ func expectSuccessfulGetRequestToURL(t *testing.T, url string) string {
 		t.Fatalf("failed reading GET response from %s:\n%v", url, err)
 	}
 	response := string(body)
-	fmt.Printf("Response from %s: %s", url, response)
+	t.Logf("Response from %s: %s", url, response)
 	return response
 }

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -68,6 +68,6 @@ k run iptables-tester \
         --restart=Never \
         --rm \
         -- \
-        go test -v -integration-tests
+        go test -integration-tests
 
 k delete ns proxy-init-test


### PR DESCRIPTION
* Follow-up 787327a by making the HTTP client set an explicit 1s connect
  timeout (not a request timeout). Use this client in all tests.
* Use `t.Helper()` so that failures are annotated at the callsite and
  not in the test helper.
* Use `t.Logf` instead of `fmt.Println` so that logs are only printed on
  failure, cleaning up test output.
* Disable verbose logging in the test runner.
* Add a `makeURL` helper that uses `net.JoinHostPort` to construct URLs.
* Make most helpers take an URL rather than construct one internally
  (for consistency);
* Use simpler variable names wherever possible

Signed-off-by: Oliver Gould <ver@buoyant.io>