### PR TITLE
Update Go version to v1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,15 @@
 module github.com/linkerd/linkerd2-proxy-init
 
-go 1.16
+go 1.18
 
 require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )


### PR DESCRIPTION
Dockerfiles for proxy-init and tester use Go v1.18 to build the source
code. This change also bumps the go.mod value. After tidying the module
file, we also get all indirect dependencies listed.

Signed-off-by: Matei David <matei@buoyant.io>