### PR TITLE
Suggestions for #92

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
         "golang.go",
         "kokakiwi.vscode-just",
         "NathanRidley.autotrim",
+        "rust-lang.rust-analyzer",
         "samverschueren.final-newline",
         "tamasfe.even-better-toml"
     ],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,21 +69,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "drain"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f1a0abf3fcefad9b4dd0e414207a7408e12b68414a01e6bb19b897d5bd7632d"
-dependencies = [
- "tokio",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
-
-[[package]]
 name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,8 +113,6 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3583ea5ed19b357df067fa668fc00ddac5d6945a5803e2114c3ed000af1f3cf"
 dependencies = [
- "drain",
- "futures-core",
  "thiserror",
  "tokio",
  "tracing",
@@ -522,6 +505,7 @@ name = "validator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "clap",
  "kubert",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,5 @@
 [workspace]
-members = [
-    "validator",
-]
+members = ["validator"]
 
 [profile.release]
 lto = true

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -1,15 +1,23 @@
 [package]
- name = "validator"
- version = "0.1.0"
- authors = ["Linkerd Authors <cncf-linkerd-dev@lists.cncf.io>"]
- edition = "2018"
- license = "Apache-2.0"
- publish = false
+name = "validator"
+version = "0.1.0"
+authors = ["Linkerd Authors <cncf-linkerd-dev@lists.cncf.io>"]
+edition = "2018"
+license = "Apache-2.0"
+publish = false
 
- [dependencies]
- anyhow = "1"
- clap = { version = "3", default-features = false, features = ["derive", "env", "std"] }
- kubert = { version = "0.8", features = ["log", "shutdown"] }
- rand = "0.8"
- tokio = { version = "1", features = ["rt", "macros", "net", "sync", "time", "io-util"] }
- tracing = "0.1"
+[dependencies]
+anyhow = "1"
+bytes = "1"
+kubert = { version = "0.8", features = ["log"] }
+rand = "0.8"
+tracing = "0.1"
+
+[dependencies.clap]
+version = "3"
+default-features = false
+features = ["derive", "env", "std"]
+
+[dependencies.tokio]
+version = "1"
+features = ["io-util", "macros", "net", "rt", "signal", "time"]

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, info, Instrument};
 /// Validate that a container's networking is setup for the Linkerd proxy
 ///
 /// Validation is done by binding a server on the proxy's outbound port and
-/// initiatinga connection to an arbitrary (hopefully unroutable) address. If
+/// initiating a connection to an arbitrary (hopefully unroutable) address. If
 /// networking has been configured properly, the connection should be
 /// established to the server.
 #[derive(Parser)]
@@ -90,14 +90,14 @@ async fn main() {
     }
 }
 
-// === Valdiation ===
+// === Validation ===
 
 /// Validates that connecting to `connect_addr` actually connects to
 /// `listen_addr`.
 ///
-/// This validates the the operating system (i.e. iptables) is configured to
+/// This validates that the operating system (i.e. iptables) is configured to
 /// redirect connections to a Linkerd proxy (with an outbound port of
-/// `listen_addr).
+/// `listen_addr`).
 async fn validate(listen_addr: SocketAddr, connect_addr: SocketAddr) -> Result<()> {
     // First, bind the server address so that all connections can be processed
     // by the server.
@@ -118,7 +118,7 @@ async fn validate(listen_addr: SocketAddr, connect_addr: SocketAddr) -> Result<(
     tokio::spawn(serve(listener, token.clone()).in_current_span());
 
     // Connect to an arbitrary address, read data from the connection, and fail
-    // if it does match the server's token.
+    // if it doesn't match the server's token.
     info!("Connecting to {connect_addr}");
     let data = connect(connect_addr, token.len()).await?;
     debug!(data = ?String::from_utf8_lossy(&*data), size = data.len());

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -171,6 +171,9 @@ async fn connect(addr: SocketAddr, size: usize) -> Result<Bytes> {
     while buf.len() != size {
         let size = socket.read_buf(&mut buf).await?;
         debug!(bytes = %size, "Read message from server");
+        if size == 0 {
+            break;
+        }
     }
     Ok(buf.freeze())
 }


### PR DESCRIPTION
* There's no need to have synchronization between the client and server.
  We can instead bind the listener before doing anything with the client
  to ensure that the process is listening.
* Use a longer token string, ended with a newline (for aesthetics when
  using netcat, etc).
* Use `bytes` to store the server token.
* Change environment prefix to `LINKERD_VALIDATOR_` (instead of `CNI_`).
* Change the default log level to simply `info`. (No logs were emitted
  by default).
* Rename `target-addr` to `connect-addr` and rename
  `outbound-proxy-addr` to `server-addr`. This makes it easier to
  understand them in the context of this application.
* Apply a single top-level timeout, instead of applying the timeout
  independently on each call.
* Change the timeout to 10s. There's no use waiting for 2 minutes when
  we don't do any sort of retrying, etc.
* Replace `kubert::shutdown` with `tokio::signal` -- we don't actually
  need graceful of draining of anything in the process, we just need to
  stop the process when a signal is received.
* Add comments throughout.

Signed-off-by: Oliver Gould <ver@buoyant.io>