### PR TITLE
dev: Update to v28

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "linkerd2",
-    "image": "ghcr.io/linkerd/dev:v22",
+    "image": "ghcr.io/linkerd/dev:v28",
     "extensions": [
         "DavidAnson.vscode-markdownlint",
         "golang.go",

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - .devcontainer/devcontainer.json
       - .github/workflows/**
+      - justfile
 
 permissions:
   contents: read
@@ -13,32 +14,14 @@ jobs:
   actionlint:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
-    container: ghcr.io/linkerd/dev:v22-tools
+    container: ghcr.io/linkerd/dev:v28-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - name: Run actionlint
-        run: |
-          # shellcheck disable=SC2016
-          actionlint \
-            -format '{{range $err := .}}::error file={{$err.Filepath}},line={{$err.Line}},col={{$err.Column}}::{{$err.Message}}%0A```%0A{{replace $err.Snippet "\\n" "%0A"}}%0A```\n{{end}}' \
-            .github/workflows/*
+      - run: just action-lint
 
   devcontainer-versions:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v22-tools
+    container: ghcr.io/linkerd/dev:v28-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - name: Scan workflows for other Devcontainer image versions
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Strip jsonc comments because `jq` doesn't support them.
-          image=$(json5-to-json <.devcontainer/devcontainer.json |jq -r '.image')
-          for f in .github/workflows/* ; do
-            for i in $(yq '.jobs.* | .container.image // .container // "" | match("ghcr.io/linkerd/dev:v[0-9]+").string' < "$f") ; do
-              if [ "$i" != "$image" ]; then
-                echo "::error file=$f::Workflow '$f' uses incorrect Devcontainer image '$i'"
-                exit 1
-              fi
-            done
-          done
+      - run: just action-dev-check

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,14 +17,14 @@ jobs:
 
   fmt:
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v22-go
+    container: ghcr.io/linkerd/dev:v28-go
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just go-fmt-check
 
   unit-test:
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v22-go
+    container: ghcr.io/linkerd/dev:v28-go
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just proxy-init-test-unit

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,0 +1,20 @@
+name: Markdown
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - .github/workflows/markdown.yml
+
+jobs:
+  md-lint:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: DavidAnson/markdownlint-cli2-action@e3969ef4ed874458f4b66d4631f78fff7717012c
+        with:
+            globs: "**/*.md"

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -1,0 +1,20 @@
+name: Shell
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - '**/*.sh'
+      - .github/workflows/shellcheck.yml
+      - justfile
+
+jobs:
+  sh-lint:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    container: ghcr.io/linkerd/dev:v28-tools
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - run: just sh-lint


### PR DESCRIPTION
* Use a unified action-dev-check script to audit devcontainer versions
* Unify a `just lint` recipe to cover linting all languages (with
  md-lint and sh-lint).
* Add markdown and shell linting workflows.

Signed-off-by: Oliver Gould <ver@buoyant.io>