### PR TITLE
Add validator to build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,5 @@ RUN setcap cap_net_raw,cap_net_admin+eip /sbin/xtables-legacy-multi && \
     setcap cap_net_raw,cap_net_admin+eip /sbin/xtables-nft-multi && \
     setcap cap_net_raw,cap_net_admin+eip /usr/local/bin/proxy-init
 
-
 USER 65534
 ENTRYPOINT ["/usr/local/bin/proxy-init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,16 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/linkerd2-proxy-
 ##
 
 # Compile from target platform to target arch
-FROM --platform=$TARGETPLATFORM docker.io/library/rust:1.62.1 as rust
+FROM --platform=$TARGETPLATFORM docker.io/library/rust:1.63.0-slim as rust
 WORKDIR /build
 COPY Cargo.toml Cargo.lock .
 COPY validator /build/
 ARG TARGETARCH
 RUN --mount=type=cache,target=target \
-   --mount=type=cache,from=rust:1.62.1,source=/usr/local/cargo,target=/usr/local/cargo \
+   --mount=type=cache,from=docker.io/library/rust:1.63.0-slim,source=/usr/local/cargo,target=/usr/local/cargo \
    cargo fetch
 RUN --mount=type=cache,target=target \
-   --mount=type=cache,from=rust:1.62.1,source=/usr/local/cargo,target=/usr/local/cargo \
+   --mount=type=cache,from=docker.io/library/rust:1.63.0-slim,source=/usr/local/cargo,target=/usr/local/cargo \
    target=$(rustup show | sed -n 's/^Default host: \(.*\)/\1/p' | sed 's/-gnu$/-musl/') ; \
    rustup target add "${target}" && \
    cargo build --locked --target="$target" --release --package=linkerd-network-validator && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-## Compile proxy-init utility
-FROM --platform=$BUILDPLATFORM golang:1.18-alpine as build
+##
+## Go
+##
+
+# Cross compile from native platform to target arch
+FROM --platform=$BUILDPLATFORM golang:1.18-alpine as go
 WORKDIR /build
 COPY go.mod .
 COPY go.sum .
@@ -8,14 +12,44 @@ COPY ./proxy-init ./proxy-init
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/linkerd2-proxy-init -mod=readonly -ldflags "-s -w" -v ./proxy-init
 
-## Package runtime
-FROM --platform=$TARGETPLATFORM alpine:3.16.2
+##
+## Rust
+##
+
+# Compile from target platform to target arch
+FROM --platform=$TARGETPLATFORM docker.io/library/rust:1.62.1 as rust
+WORKDIR /build
+COPY Cargo.toml Cargo.lock .
+COPY validator /build/
+ARG TARGETARCH
+RUN --mount=type=cache,target=target \
+   --mount=type=cache,from=rust:1.62.1,source=/usr/local/cargo,target=/usr/local/cargo \
+   cargo fetch
+RUN --mount=type=cache,target=target \
+   --mount=type=cache,from=rust:1.62.1,source=/usr/local/cargo,target=/usr/local/cargo \
+   target=$(rustup show | sed -n 's/^Default host: \(.*\)/\1/p' | sed 's/-gnu$/-musl/') ; \
+   rustup target add "${target}" && \
+   cargo build --locked --target="$target" --release --package=linkerd-network-validator && \
+   mv "target/${target}/release/linkerd-network-validator" /tmp/
+
+##
+## Runtime
+## 
+
+FROM --platform=$TARGETPLATFORM alpine:3.16.2 as runtime
 RUN apk add iptables libcap && \
     touch /run/xtables.lock && \
     chmod 0666 /run/xtables.lock
-COPY --from=build /out/linkerd2-proxy-init /usr/local/bin/proxy-init
+
+# Copy proxy-init and validator binaries in the bin directory
+COPY --from=go /out/linkerd2-proxy-init /usr/local/bin/proxy-init
+COPY --from=rust /tmp/linkerd-network-validator /usr/local/bin/
+
+# Set sys caps for iptables utilities and proxy-init
 RUN setcap cap_net_raw,cap_net_admin+eip /sbin/xtables-legacy-multi && \
     setcap cap_net_raw,cap_net_admin+eip /sbin/xtables-nft-multi && \
     setcap cap_net_raw,cap_net_admin+eip /usr/local/bin/proxy-init
+
+
 USER 65534
 ENTRYPOINT ["/usr/local/bin/proxy-init"]


### PR DESCRIPTION
This change adds the validator to the repository's build process.
Instead of maintaing a separate Dockerfile, and a separate release step
in the workflow (along with additional just recipes, and so on), the
validator is built in the same Dockerfile as proxy-init. The resulting
binary is added to the runtime image.

The validator can be run by modifying the entrypoint in the manifest to
call `linkerd-network-validator` instead of proxy-init. The validator is
statically linked to musl.

Signed-off-by: Matei David <matei@buoyant.io>

----

Tested the new image to make sure validation works:

❌  Unsuccessful validation (proxy-init runs after validator)

```yaml
kind: Deployment
metadata:
  name: validation-test
spec:
  selector:
    matchLabels:
      app: validation-test
  template:
    metadata:
      labels:
        app: validation-test
    spec:
      containers:
      - image: nginx
        imagePullPolicy: IfNotPresent
        name: nginx
      initContainers:
      - args:
        - --log-level
        - debug
        command:
        - linkerd-network-validator
        image: test.l5d.io/linkerd/proxy-init:test
        imagePullPolicy: Never
        name: validator
      - args:
        - --incoming-proxy-port
        - "4143"
        - --outgoing-proxy-port
        - "4140"
        - --proxy-uid
        - "2102"
        - --inbound-ports-to-ignore
        - 4190,4191,4567,4568
        - --outbound-ports-to-ignore
        - 4567,4568
        image: test.l5d.io/linkerd/proxy-init:test
        imagePullPolicy: IfNotPresent
        name: linkerd-init
        resources:
          limits:
            cpu: 100m
            memory: 20Mi
          requests:
            cpu: 100m
            memory: 20Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            add:
            - NET_ADMIN
            - NET_RAW
          privileged: false
          readOnlyRootFilesystem: true
          runAsNonRoot: true
```

```
:; k logs validation-test-7d9b4bd47d-m4522 validation
2022-08-19T15:02:24.507770Z  INFO linkerd_network_validator: Listening for connections on 0.0.0.0:4140
2022-08-19T15:02:24.507785Z DEBUG linkerd_network_validator: token="RP6nxA9mJcEhFiCjx24YWDQ2YKbZLgLCTvq8zCuLi2ta8EWikzdSpLXzCfvC7CJ\n"
2022-08-19T15:02:24.507791Z  INFO linkerd_network_validator: Connecting to 192.0.2.2:1404
2022-08-19T15:02:34.508129Z ERROR linkerd_network_validator: Failed to validate networking configuration timeout=10s
```

✔️  Successful validation (proxy-init runs before validator)

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: validation-test
spec:
  selector:
    matchLabels:
      app: validation-test
  template:
    metadata:
      labels:
        app: validation-test
    spec:
      containers:
      - image: nginx
        imagePullPolicy: IfNotPresent
        name: nginx
      initContainers:
      - args:
        - --incoming-proxy-port
        - "4143"
        - --outgoing-proxy-port
        - "4140"
        - --proxy-uid
        - "2102"
        - --inbound-ports-to-ignore
        - 4190,4191,4567,4568
        - --outbound-ports-to-ignore
        - 4567,4568
        image: test.l5d.io/linkerd/proxy-init:test
        imagePullPolicy: IfNotPresent
        name: linkerd-init
        resources:
          limits:
            cpu: 100m
            memory: 20Mi
          requests:
            cpu: 100m
            memory: 20Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            add:
            - NET_ADMIN
            - NET_RAW
          privileged: false
          readOnlyRootFilesystem: true
          runAsNonRoot: true
      - args:
         - --log-level
         - debug
        command:
         - linkerd-network-validator
        image: test.l5d.io/linkerd/proxy-init:test
        imagePullPolicy: Never
        name: validator
```

```
:; k logs validation-test-59db667c67-xn9sd validator
2022-08-19T15:03:49.655998Z  INFO linkerd_network_validator: Listening for connections on 0.0.0.0:4140
2022-08-19T15:03:49.656029Z DEBUG linkerd_network_validator: token="xooRX9HeIN0eBby0rxrzkJTfQs9btTPrWQFMZwg7ZaLBYndDuQS0XB6SGYJNuK8\n"
2022-08-19T15:03:49.656052Z  INFO linkerd_network_validator: Connecting to 192.0.2.2:1404
2022-08-19T15:03:49.656122Z DEBUG connect: linkerd_network_validator: Connected client.addr=10.42.0.4:42472
2022-08-19T15:03:49.656136Z DEBUG serve:conn{client.addr=10.42.0.4:42472}: linkerd_network_validator: Accepted
2022-08-19T15:03:49.656150Z DEBUG serve:conn{client.addr=10.42.0.4:42472}: linkerd_network_validator: Wrote message to client bytes=64
2022-08-19T15:03:49.656164Z DEBUG connect: linkerd_network_validator: Read message from server bytes=64
2022-08-19T15:03:49.656182Z DEBUG linkerd_network_validator: data="xooRX9HeIN0eBby0rxrzkJTfQs9btTPrWQFMZwg7ZaLBYndDuQS0XB6SGYJNuK8\n" size=64
2022-08-19T15:03:49.656187Z  INFO linkerd_network_validator: Validated
```