### PR TITLE
Revert "Bump library/rust from 1.63.0-slim to 1.64.0-slim (#109)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/linkerd2-proxy-
 ##
 
 # Compile from target platform to target arch
-FROM --platform=$TARGETPLATFORM docker.io/library/rust:1.64.0-slim as rust
+FROM --platform=$TARGETPLATFORM docker.io/library/rust:1.63.0-slim as rust
 WORKDIR /build
 COPY Cargo.toml Cargo.lock .
 COPY validator /build/


### PR DESCRIPTION
This reverts commit 59fc11fdcc109b8a773a2fd08239ea197712196d.

I thought we were on 1.64 in linkerd2 as well, but we're not. We can make this change once that happens and we update `rust-toolchain` as well.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>