### PR TITLE
ci: Avoid invoking cargo on non-rust changes

### DIFF
--- a/.github/docker-prune.sh
+++ b/.github/docker-prune.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 
 # Delete all files under the buildkit blob directory that are not referred
 # to any longer in the cache manifest file

--- a/.github/docker-prune.sh
+++ b/.github/docker-prune.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Delete all files under the buildkit blob directory that are not referred
+# to any longer in the cache manifest file
+manifest_sha=$(jq -r .manifests[0].digest < "$RUNNER_TEMP/.buildx-cache/index.json")
+manifest=${manifest_sha#"sha256:"}
+files=("$manifest")
+while IFS= read -r f; do
+    files+=("$f")
+done < <(jq -r '.manifests[].digest | sub("^sha256:"; "")' < "$RUNNER_TEMP/.buildx-cache/blobs/sha256/$manifest")
+
+for file in "$RUNNER_TEMP"/.buildx-cache/blobs/sha256/*; do
+    for name in "${files[@]}"; do
+        if [[ "${file##*/}" == "$name" ]]; then
+            rm -f "$file"
+            echo "deleted: $name"
+            break;
+        fi
+    done
+done

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,6 +14,9 @@ jobs:
   integration:
     timeout-minutes: 15
     runs-on: ubuntu-20.04
+    env:
+      # Prevent the justfile from using cargo to lookup the validator version.
+      VALIDATOR_VERSION: unused
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,15 +14,10 @@ jobs:
   integration:
     timeout-minutes: 15
     runs-on: ubuntu-20.04
-    env:
-      # Prevent the justfile from using cargo to lookup the validator version.
-      VALIDATOR_VERSION: unused
+    container: ghcr.io/linkerd/dev:v30-tools
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76
-      - uses: AbsaOSS/k3d-action@b176c2a6dcae72e3e64e3e4d61751904ec314002
-        with:
-          cluster-name: l5d-test
+      - run: just k3d-create
       - run: just proxy-init-image
       - run: just proxy-init-test-image
       - run: just proxy-init-test-integration-deps

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,10 +14,12 @@ jobs:
   integration:
     timeout-minutes: 15
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v30-tools
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - run: just k3d-create
+      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76
+      - uses: AbsaOSS/k3d-action@b176c2a6dcae72e3e64e3e4d61751904ec314002
+        with:
+          cluster-name: l5d-test
       - run: just proxy-init-image
       - run: just proxy-init-test-image
       - run: just proxy-init-test-integration-deps

--- a/.github/workflows/release-proxy-init.yml
+++ b/.github/workflows/release-proxy-init.yml
@@ -44,7 +44,6 @@ jobs:
     permissions:
       id-token: write # needed for signing the images with GitHub OIDC token
     steps:
-      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76
       - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
       - uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
 
@@ -61,7 +60,7 @@ jobs:
               --cache-from type=local,src="$RUNNER_TEMP/.buildx-cache" \
               --cache-to type=local,dest="$RUNNER_TEMP/.buildx-cache",mode=max \
               --platform="linux/amd64,linux/arm64,linux/arm/v7"
-      - run: just action-prune-docker
+      - run: .github/docker-prune.sh
 
       # Only publish images on release
       - if: needs.meta.outputs.mode == 'release'

--- a/.github/workflows/release-validator.yml
+++ b/.github/workflows/release-validator.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/linkerd/dev:v30-rust
     steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - id: meta
         shell: bash
         run: |
@@ -32,8 +33,6 @@ jobs:
               echo mode=test
             ) >> "$GITHUB_OUTPUT"
           fi
-      - if: steps.meta.outputs.mode == 'release'
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - if: steps.meta.outputs.mode == 'release'
         name: Check that validator version matches release version
         shell: bash

--- a/.github/workflows/release-validator.yml
+++ b/.github/workflows/release-validator.yml
@@ -14,7 +14,7 @@ jobs:
   meta:
     timeout-minutes: 3
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v30-tools
+    container: ghcr.io/linkerd/dev:v30-rust
     steps:
       - id: meta
         shell: bash
@@ -28,7 +28,7 @@ jobs:
             ) >> "$GITHUB_OUTPUT"
           else
             sha="${{ github.sha }}"
-            ( echo version="test-${sha:0:7}"
+            ( echo version="v$(just validator --evaluate version)-${sha:0:7}"
               echo mode=test
             ) >> "$GITHUB_OUTPUT"
           fi
@@ -38,8 +38,7 @@ jobs:
         name: Check that validator version matches release version
         shell: bash
         run: |
-          version=$(cargo metadata --format-version=1 \
-              | jq -r '.packages[] | select(.name == "linkerd-network-validator") | .version')
+          version=$(just validator --evaluate version)
           # shellcheck disable=SC2193
           if [[ "v${version}" != '${{ steps.meta.outputs.version }}' ]]; then
             echo "::error ::Crate version v${version} does not match tag ${{ steps.meta.outputs.version }}"
@@ -78,7 +77,7 @@ jobs:
           ) >> "$GITHUB_ENV"
 
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - run: just validator-package
+      - run: just validator package
         env:
           CARGO_RELEASE: "1"
           VALIDATOR_VERSION: ${{ needs.meta.outputs.version }}

--- a/justfile
+++ b/justfile
@@ -172,7 +172,7 @@ proxy-init-image:
     docker buildx build . \
         --tag={{ _image }} \
         --platform={{ docker-arch }} \
-        --load \
+        --load
 
 # Build docker image for iptables-tester (Development)
 proxy-init-test-image:

--- a/justfile
+++ b/justfile
@@ -287,25 +287,3 @@ sh-lint:
     done < <(find . -type f ! \( -path ./.git/\* -or -path \*/target/\* \)) | xargs)
     echo "shellcheck $files" >&2
     shellcheck $files
-
-# Prune Docker BuildKit cache (in CI)
-action-prune-docker:
-    #!/usr/bin/env bash
-    set -euxo pipefail
-    # Delete all files under the buildkit blob directory that are not referred
-    # to any longer in the cache manifest file
-    manifest_sha=$(jq -r .manifests[0].digest < "$RUNNER_TEMP/.buildx-cache/index.json")
-    manifest=${manifest_sha#"sha256:"}
-    files=("$manifest")
-    while IFS= read -r f; do
-        files+=("$f")
-    done < <(jq -r '.manifests[].digest | sub("^sha256:"; "")' < "$RUNNER_TEMP/.buildx-cache/blobs/sha256/$manifest")
-    for file in "$RUNNER_TEMP"/.buildx-cache/blobs/sha256/*; do
-        for name in "${files[@]}"; do
-            if [[ "${file##*/}" == "$name" ]]; then
-                rm -f "$file"
-                echo "deleted: $name"
-                break;
-            fi
-        done
-    done

--- a/validator/.justfile
+++ b/validator/.justfile
@@ -1,0 +1,65 @@
+# This justfile includes recipes for building and packaging the validator for
+# release. This file is separated so that we can invoke cargo, etc when building
+# defaults. If this logic were in the top-level justfile, then these tools would
+# be invoked (possibly updating Rust, etc), for unrelated targets.
+#
+# Users are expected to interact with this via the top-level Justfile.
+
+# The version name to use for packages.
+version := env_var_or_default("VALIDATOR_VERSION", ```
+    cd .. && cargo metadata --format-version=1 \
+        | jq -r '.packages[] | select(.name == "linkerd-network-validator") | .version' \
+        | head -n 1
+    ```)
+
+# The architecture name to use for packages. Either 'amd64', 'arm64', or 'arm'.
+_arch := env_var_or_default("ARCH", "amd64")
+
+# If an `_arch` is specified, then we change the default cargo `--target` to
+# support cross-compilation. Otherwise, we use `rustup` to find the default.
+_cargo-target := if _arch == "amd64" {
+        "x86_64-unknown-linux-musl"
+    } else if _arch == "arm64" {
+        "aarch64-unknown-linux-musl"
+    } else if _arch == "arm" {
+        "armv7-unknown-linux-musleabihf"
+    } else {
+        `rustup show | sed -n 's/^Default host: \(.*\)/\1/p'`
+    }
+
+_target-dir := "../target" / _cargo-target / "release"
+_bin := _target-dir / "linkerd-network-validator"
+_package-name := "linkerd-network-validator-" + version + "-" + _arch
+_package-dir := "../target/package"
+_shasum := "shasum -a 256"
+
+export RUST_BACKTRACE := env_var_or_default("RUST_BACKTRACE", "short")
+
+# Support cross-compilation when `_arch` changes.
+_strip := if _arch == "arm64" { "aarch64-linux-gnu-strip" } else if _arch == "arm" { "arm-linux-gnueabihf-strip" } else { "strip" }
+
+_cargo := env_var_or_default("CARGO", "cargo")
+
+# If recipe is run in github actions (and cargo-action-fmt is installed), then add a
+# command suffix that formats errors
+_cargo-fmt := if env_var_or_default("GITHUB_ACTIONS", "") != "true" { "" } else {
+    ```
+    if command -v cargo-action-fmt >/dev/null 2>&1 ; then
+        echo "--message-format=json | cargo-action-fmt"
+    fi
+    ```
+}
+
+package: build
+    @-mkdir -p {{ _package-dir }}
+    cp {{ _bin }} {{ _package-dir / _package-name }}
+    {{ _strip }} {{ _package-dir / _package-name }}
+    {{ _shasum }} {{ _package-dir / _package-name }} > {{ _package-dir / _package-name }}.shasum
+
+build *flags:
+    {{ _cargo }} fetch --locked
+    {{ _cargo }} build --workspace -p linkerd-network-validator \
+        --release \
+        --target={{ _cargo-target }} \
+        {{ flags }} \
+        {{ _cargo-fmt }}


### PR DESCRIPTION
Currently the `justfile` invokes `cargo` to determine the validator version. This means that it will install the Rust version in `rust-toolchain` when the runner OS includes another Rust version. This is unnecessary in the proxy-init release workflow.

This change removes the `action-prune-docker` just recipe to a dedicated script in `.github/docker-prune.sh` so that it can be run without any of the `justfile` dependencies. This also makes the script covered by `just sh-lint`.

This change also moves validator packaging into a dedicated `validator/.justfile` so that invoking the top-level justfile does not eagerly load defaults with `cargo`.

Signed-off-by: Oliver Gould <ver@buoyant.io>