### PR TITLE
init -> proxy-init

### DIFF
--- a/.github/workflows/release-proxy-init.yml
+++ b/.github/workflows/release-proxy-init.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - .github/workflows/release-proxy-init.yml
   push:
-    tags: ["init/v*"]
+    tags: ["proxy-init/v*"]
 
 permissions:
   contents: read


### PR DESCRIPTION
Small fix to proxy-init release pipeline.

The release workflow in jobs.meta looks for tags matching 'proxy-init' while the workflow in on.push looks for tags matching 'init'. This change makes the two patterns match.

I pushed a tag called `init/v2.1.0` and noticed it was triggering the test workflow. This should correct that.

Signed-off-by: Steve Jenson <stevej@buoyant.io>