### PR TITLE
Adds a prescriptive logging message when validator fails.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
 
 [[package]]
 name = "linkerd-network-validator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkerd-network-validator"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Linkerd Authors <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -83,7 +83,7 @@ async fn main() {
         // error.
         () = tokio::time::sleep(timeout) => {
             error!(?timeout, "Failed to validate networking configuration. \
-            Check that iptables or firewall rules are working as expected.");
+            Please ensure iptables rules are rewriting traffic as expected.");
             exit(UNSUCCESSFUL_EXIT_CODE);
         }
 
@@ -130,7 +130,7 @@ async fn validate(listen_addr: SocketAddr, connect_addr: SocketAddr) -> Result<(
     // if it doesn't match the server's token.
     info!("Connecting to {connect_addr}");
     let data = connect(connect_addr, token.len()).await.map_err(|error| {
-        error!(%error, "Unable to connect to validator. Please ensure iptables or firewall \
+        error!(%error, "Unable to connect to validator. Please ensure iptables \
                         rules are rewriting traffic as expected");
         error
     })?;


### PR DESCRIPTION
If an administrator sees a validator failure message, make it clear that the error is in their environment rather than the tool.

Signed-off-by: Steve Jenson <stevej@buoyant.io>