### PR TITLE
When existing chains are found, log at info

### DIFF
--- a/proxy-init/internal/iptables/iptables.go
+++ b/proxy-init/internal/iptables/iptables.go
@@ -78,7 +78,7 @@ func ConfigureFirewall(firewallConfiguration FirewallConfiguration) error {
 	matches := chainRegex.FindAllString(b.String(), 1)
 	if len(matches) > 0 {
 		log.Infof("skipping iptables setup: found %d existing chains", len(matches))
-		log.Debugf("matching chains: %v", matches)
+		log.Infof("matching chains: %v", matches)
 		return nil
 	}
 


### PR DESCRIPTION
When existing chains are found, we usually want to know what those chains are to
help debugging. For example, this would be helpful in linkerd/linkerd2#9267
without having to set the log level to `debug` and waiting for the issue to
occur again.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>