### PR TITLE
Dockerfile for cni-plugin and docker-based tests for CNI installer script

### DIFF
--- a/.github/workflows/cni-plugin-installer.yml
+++ b/.github/workflows/cni-plugin-installer.yml
@@ -1,0 +1,19 @@
+name: cni-plugin-installer
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - cni-plugin/deployment/scripts/**
+
+jobs:
+  run-tests:
+    timeout-minutes: 15
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: linkerd/dev/actions/setup-tools@v38
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76
+      - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
+      - uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+      - run: just cni-plugin-installer-integration-run

--- a/.github/workflows/cni-plugin-installer.yml
+++ b/.github/workflows/cni-plugin-installer.yml
@@ -14,6 +14,5 @@ jobs:
       - uses: linkerd/dev/actions/setup-tools@v38
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76
-      - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
       - uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
       - run: just cni-plugin-installer-integration-run

--- a/Dockerfile-cni-plugin
+++ b/Dockerfile-cni-plugin
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.4
 
-ARG BUILDPLATFORM=linux/amd64
+##
+## Go
+##
 
-# Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.18-alpine as golang
-WORKDIR /linkerd-build
+# Cross compile from native platform to target arch
+FROM --platform=$BUILDPLATFORM ghcr.io/linkerd/dev:v38-go as go
+WORKDIR /build
 COPY --link go.mod go.sum .
 COPY --link ./cni-plugin ./cni-plugin
 COPY --link ./proxy-init ./proxy-init
@@ -31,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy \
     && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
-COPY --from=golang /go/bin/linkerd-cni /opt/cni/bin/
+COPY --from=go /go/bin/linkerd-cni /opt/cni/bin/
 COPY LICENSE .
 COPY cni-plugin/deployment/scripts/install-cni.sh .
 COPY cni-plugin/deployment/linkerd-cni.conf.default .

--- a/Dockerfile-cni-plugin
+++ b/Dockerfile-cni-plugin
@@ -35,8 +35,8 @@ RUN update-alternatives --set iptables /usr/sbin/iptables-legacy \
 
 COPY --from=go /go/bin/linkerd-cni /opt/cni/bin/
 COPY LICENSE .
-COPY --from=go cni-plugin/deployment/scripts/install-cni.sh .
-COPY --from=go cni-plugin/deployment/linkerd-cni.conf.default .
-COPY --from=go cni-plugin/deployment/scripts/filter.jq .
+COPY --from=go ./cni-plugin/deployment/scripts/install-cni.sh .
+COPY --from=go ./cni-plugin/deployment/linkerd-cni.conf.default .
+COPY --from=go ./cni-plugin/deployment/scripts/filter.jq .
 ENV PATH=/linkerd:/opt/cni/bin:$PATH
 CMD ["install-cni.sh"]

--- a/Dockerfile-cni-plugin
+++ b/Dockerfile-cni-plugin
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.4
+
+ARG BUILDPLATFORM=linux/amd64
+
+# Precompile key slow-to-build dependencies
+FROM --platform=$BUILDPLATFORM golang:1.18-alpine as golang
+WORKDIR /linkerd-build
+COPY --link go.mod go.sum .
+COPY --link ./cni-plugin ./cni-plugin
+COPY --link ./proxy-init ./proxy-init
+COPY --link ./internal ./internal
+RUN go mod download
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on \
+    go build -o /go/bin/linkerd-cni -mod=readonly -ldflags "-s -w" -v ./cni-plugin/
+
+##
+## Runtime
+##
+
+FROM debian:bullseye-slim
+WORKDIR /linkerd
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    iptables \
+    inotify-tools \
+    procps \
+    jq && \
+    rm -rf /var/lib/apt/lists/*
+
+# We still rely on old iptables-legacy syntax.
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+COPY --from=golang /go/bin/linkerd-cni /opt/cni/bin/
+COPY LICENSE .
+COPY cni-plugin/deployment/scripts/install-cni.sh .
+COPY cni-plugin/deployment/linkerd-cni.conf.default .
+COPY cni-plugin/deployment/scripts/filter.jq .
+ENV PATH=/linkerd:/opt/cni/bin:$PATH
+CMD ["install-cni.sh"]

--- a/Dockerfile-cni-plugin
+++ b/Dockerfile-cni-plugin
@@ -35,8 +35,8 @@ RUN update-alternatives --set iptables /usr/sbin/iptables-legacy \
 
 COPY --from=go /go/bin/linkerd-cni /opt/cni/bin/
 COPY LICENSE .
-COPY --from=go ./cni-plugin/deployment/scripts/install-cni.sh .
-COPY --from=go ./cni-plugin/deployment/linkerd-cni.conf.default .
-COPY --from=go ./cni-plugin/deployment/scripts/filter.jq .
+COPY cni-plugin/deployment/scripts/install-cni.sh .
+COPY cni-plugin/deployment/linkerd-cni.conf.default .
+COPY cni-plugin/deployment/scripts/filter.jq .
 ENV PATH=/linkerd:/opt/cni/bin:$PATH
 CMD ["install-cni.sh"]

--- a/Dockerfile-cni-plugin
+++ b/Dockerfile-cni-plugin
@@ -35,8 +35,8 @@ RUN update-alternatives --set iptables /usr/sbin/iptables-legacy \
 
 COPY --from=go /go/bin/linkerd-cni /opt/cni/bin/
 COPY LICENSE .
-COPY cni-plugin/deployment/scripts/install-cni.sh .
-COPY cni-plugin/deployment/linkerd-cni.conf.default .
-COPY cni-plugin/deployment/scripts/filter.jq .
+COPY --from=go cni-plugin/deployment/scripts/install-cni.sh .
+COPY --from=go cni-plugin/deployment/linkerd-cni.conf.default .
+COPY --from=go cni-plugin/deployment/scripts/filter.jq .
 ENV PATH=/linkerd:/opt/cni/bin:$PATH
 CMD ["install-cni.sh"]

--- a/cni-plugin/deployment/scripts/install-cni.sh
+++ b/cni-plugin/deployment/scripts/install-cni.sh
@@ -113,7 +113,7 @@ trap 'echo "SIGINT received, simply exiting..."; cleanup' INT
 trap 'echo "SIGTERM received, simply exiting..."; cleanup' TERM
 trap 'echo "SIGHUP received, simply exiting..."; cleanup' HUP
 
-# Install CNI bin will copy the linkerd-cni binary on the host's filesystem
+# Copy the linkerd-cni binary to a known location where CNI will look.
 install_cni_bin() {
   # Place the new binaries if the mounted directory is writeable.
   dir="${CONTAINER_MOUNT_PREFIX}${DEST_CNI_BIN_DIR}"

--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@
 
 proxy-init-image := "test.l5d.io/linkerd/proxy-init:test"
 _test-image := "test.l5d.io/linkerd/iptables-tester:test"
+cni-plugin-image := "test.l5d.io/linkerd/cni-plugin:test"
 
 ##
 ## Recipes
@@ -115,6 +116,20 @@ build-proxy-init-test-image *args='--load':
         --tag={{ _test-image }} \
         {{ args }}
 
+##
+## CNI
+##
+
+# TODO(stevej): this does not run within the devcontainer
+cni-plugin-installer-integration-run: build-cni-plugin-image
+    HUB=test.l5d.io/linkerd TAG=test go test -cover -v -mod=readonly ./cni-plugin/test/... -integration-tests
+
+# Build docker image for cni-plugin (Development)
+build-cni-plugin-image *args='--load':
+    docker buildx build . \
+        --file=Dockerfile-cni-plugin \
+        --tag={{ cni-plugin-image }} \
+        {{ args }}
 ##
 ## Test cluster
 ##


### PR DESCRIPTION
* justfile workflow for running docker-based integration tests
* Dockerfile-cni-plugin for building those tests along with the cni-plugin
* github workflow for running those tests when anything touches the installer
* Updated a comment in `install-cni.sh` to trigger the installer integration test

Signed-off-by: Steve Jenson <stevej@buoyant.io>