### PR TITLE
Add static and dynamic port overrides for CNI ebpf (#9841)

### DIFF
--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -36,9 +36,9 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // ProxyInit is the configuration for the proxy-init binary
@@ -263,7 +263,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			if pod.GetLabels()["controller-component"] != "" {
 				// Skip k8s api server ports on the outbound side if pod is a
 				// control plane component
-				skippedPorts, err := getApiServerPorts(ctx, client)
+				skippedPorts, err := getAPIServerPorts(ctx, client)
 				if err != nil {
 					// If we cannot retrieve the 'kubernetes' service's ports (for
 					// whatever reason), skip default ports: 443, 6443
@@ -319,7 +319,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	return nil
 }
 
-func getApiServerPorts(ctx context.Context, api *kubernetes.Clientset) ([]string, error) {
+func getAPIServerPorts(ctx context.Context, api *kubernetes.Clientset) ([]string, error) {
 	service, err := api.CoreV1().Services("default").Get(ctx, "kubernetes", metav1.GetOptions{})
 	if err != nil {
 		return []string{}, err

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // ProxyInit is the configuration for the proxy-init binary
@@ -260,9 +261,18 @@ func cmdAdd(args *skel.CmdArgs) error {
 			}
 
 			if pod.GetLabels()["controller-component"] != "" {
-				// Skip 443 outbound port if its a control plane component
-				logEntry.Debug("linkerd-cni: adding 443 to OutboundPortsToIgnore as its a control plane component")
-				options.OutboundPortsToIgnore = append(options.OutboundPortsToIgnore, "443")
+				// Skip k8s api server ports on the outbound side if pod is a
+				// control plane component
+				skippedPorts, err := getApiServerPorts(ctx, client)
+				if err != nil {
+					// If we cannot retrieve the 'kubernetes' service's ports (for
+					// whatever reason), skip default ports: 443, 6443
+					logEntry.Errorf("linkerd-cni: could not retrieve ports from 'kubernetes' service: %v", err)
+					skippedPorts = []string{"443", "6443"}
+				}
+
+				logEntry.Debugf("linkerd-cni: adding %v to OutboundPortsToIgnore as its a control plane component", skippedPorts)
+				options.OutboundPortsToIgnore = append(options.OutboundPortsToIgnore, skippedPorts...)
 			}
 
 			firewallConfiguration, err := cmd.BuildFirewallConfiguration(&options)
@@ -307,6 +317,23 @@ func cmdCheck(args *skel.CmdArgs) error {
 func cmdDel(args *skel.CmdArgs) error {
 	logrus.Debug("linkerd-cni: cmdDel not implemented")
 	return nil
+}
+
+func getApiServerPorts(ctx context.Context, api *kubernetes.Clientset) ([]string, error) {
+	service, err := api.CoreV1().Services("default").Get(ctx, "kubernetes", metav1.GetOptions{})
+	if err != nil {
+		return []string{}, err
+	}
+
+	ports := make([]string, 0)
+	for _, port := range service.Spec.Ports {
+		ports = append(ports, strconv.Itoa(int(port.Port)))
+		if port.TargetPort.Type == intstr.Int {
+			ports = append(ports, strconv.Itoa(port.TargetPort.IntValue()))
+		}
+	}
+
+	return ports, nil
 }
 
 func getAnnotationOverride(ctx context.Context, api *kubernetes.Clientset, pod *v1.Pod, key string) (string, error) {


### PR DESCRIPTION
When CNI plugins run in ebpf mode, they may rewrite the packet destination when doing socket-level load balancing (i.e in the `connect()` call). In these cases, skipping `443` on the outbound side for control plane components becomes redundant; the packet is re-written to target the actual Kubernetes API Server backend (which typically listens on port `6443`, but may be overridden when the cluster is created).

This change adds port `6443` to the list of skipped ports for control plane components. On the linkerd-cni plugin side, the ports are non-configurable. Whenever a pod with the control plane component label is handled by the plugin, we look-up the `kubernetes` service in the default namespace and append the port values (of both ClusterIP and backend) to the list.

On the initContainer side, we make this value configurable in Helm and provide a sensible default (`443,6443`). Users may override this value if the ports do not correspond to what they have in their cluster. In the CLI, if no override is given, we look-up the service in the same way that we do for linkerd-cni; if failures are encountered we fallback to the default list of ports from the values file.

Closes #9817

Signed-off-by: Matei David <matei@buoyant.io>