### PR TITLE
runs cni-plugin integration tests when dependabot changes go.mod and go.sum

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,3 +22,6 @@ jobs:
       - run: just build-proxy-init-test-image
       - run: just proxy-init-test-integration-deps
       - run: just proxy-init-test-integration-run
+      - run: just build-cni-plugin-image
+      - run: just build-cni-plugin-test-image
+      - run: just cni-plugin-test-integration


### PR DESCRIPTION
Ensures that cni-plugin integration tests are run on dependabot changes.

Signed-off-by: Steve Jenson <stevej@buoyant.io>