### PR TITLE
use the cni test image that we've just built for our tests

### DIFF
--- a/cni-plugin/integration/manifests/linkerd-cni.yaml
+++ b/cni-plugin/integration/manifests/linkerd-cni.yaml
@@ -128,6 +128,7 @@ spec:
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
         image: test.l5d.io/linkerd/cni-plugin:test
+        #image: cr.l5d.io/linkerd/cni-plugin:edge-22.12.1
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/cni-plugin/integration/manifests/linkerd-cni.yaml
+++ b/cni-plugin/integration/manifests/linkerd-cni.yaml
@@ -127,8 +127,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        #image: test.l5d.io/linkerd/cni-plugin:test
-        image: cr.l5d.io/linkerd/cni-plugin:edge-22.12.1
+        image: test.l5d.io/linkerd/cni-plugin:test
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -130,7 +130,6 @@ func parseConfig(stdin []byte) (*PluginConf, error) {
 
 // cmdAdd is called by the CNI runtime for ADD requests
 func cmdAdd(args *skel.CmdArgs) error {
-	logrus.Debug("linkerd-cni: cmdAdd, parsing config")
 	conf, err := parseConfig(args.StdinData)
 	if err != nil {
 		logrus.Errorf("error parsing config: %e", err)

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -82,10 +82,12 @@ type PluginConf struct {
 }
 
 func main() {
+	// Must log to Stderr because the CNI runtime uses Stdout as its state
+	logrus.SetOutput(os.Stderr)
 	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "")
 }
 
-func configureLogging(logLevel string) {
+func configureLoggingLevel(logLevel string) {
 	switch strings.ToLower(logLevel) {
 	case "debug":
 		logrus.SetLevel(logrus.DebugLevel)
@@ -94,9 +96,6 @@ func configureLogging(logLevel string) {
 	default:
 		logrus.SetLevel(logrus.WarnLevel)
 	}
-
-	// Must log to Stderr because the CNI runtime uses Stdout as its state
-	logrus.SetOutput(os.Stderr)
 }
 
 // parseConfig parses the supplied configuration (and prevResult) from stdin.
@@ -134,9 +133,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 	logrus.Debug("linkerd-cni: cmdAdd, parsing config")
 	conf, err := parseConfig(args.StdinData)
 	if err != nil {
+		logrus.Errorf("error parsing config: %e", err)
 		return err
 	}
-	configureLogging(conf.LogLevel)
+	configureLoggingLevel(conf.LogLevel)
 
 	if conf.PrevResult != nil {
 		logrus.WithFields(logrus.Fields{
@@ -154,6 +154,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	args.Args = strings.Replace(args.Args, "K8S_POD_NAMESPACE", "K8sPodNamespace", 1)
 	args.Args = strings.Replace(args.Args, "K8S_POD_NAME", "K8sPodName", 1)
 	if err := types.LoadArgs(args.Args, &k8sArgs); err != nil {
+		logrus.Errorf("error loading args %e", err)
 		return err
 	}
 
@@ -173,16 +174,19 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 		config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(configLoadingRules, configOverrides).ClientConfig()
 		if err != nil {
+			logrus.Errorf("linkerd-cni client err with NewNonInteractiveDeferredLoadingClientConfig: %e", err)
 			return err
 		}
 
 		client, err := kubernetes.NewForConfig(config)
 		if err != nil {
+			logrus.Errorf("linkerd-cni client err with NewForConfig: %e", err)
 			return err
 		}
 
 		pod, err := client.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
+			logrus.Errorf("linkerd-cni client err in client.Pods().Get(): %e", err)
 			return err
 		}
 

--- a/internal/iptables/iptables.go
+++ b/internal/iptables/iptables.go
@@ -234,7 +234,9 @@ func executeCommand(firewallConfiguration FirewallConfiguration, cmd *exec.Cmd) 
 		// command.
 		//
 		// See https://github.com/rancher/k3s/issues/1434#issuecomment-629315909
-		args := append([]string{"--net", firewallConfiguration.NetNs, "--"}, cmd.Args...)
+		args := []string{fmt.Sprintf("--net=%s", firewallConfiguration.NetNs)}
+		args = append(args, "--")
+		args = append(args, cmd.Args...)
 		cmd = exec.Command("nsenter", args...)
 	}
 	log.Info(cmd.String())

--- a/internal/iptables/iptables.go
+++ b/internal/iptables/iptables.go
@@ -234,9 +234,8 @@ func executeCommand(firewallConfiguration FirewallConfiguration, cmd *exec.Cmd) 
 		// command.
 		//
 		// See https://github.com/rancher/k3s/issues/1434#issuecomment-629315909
-		args := []string{fmt.Sprintf("--net=%s", firewallConfiguration.NetNs)}
-		args = append(args, "--")
-		args = append(args, cmd.Args...)
+		nsArgs := fmt.Sprintf("--net=%s", firewallConfiguration.NetNs)
+		args := append([]string{nsArgs, "--"}, cmd.Args...)
 		cmd = exec.Command("nsenter", args...)
 	}
 	log.Info(cmd.String())


### PR DESCRIPTION
We were using an edge release before which was not testing our changes.

Signed-off-by: Steve Jenson <stevej@buoyant.io>