### PR TITLE
Improve narration and discuss use of `internal` in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,14 +20,20 @@ relies on code living there.
 `git log proxy-init/v2.1.0..HEAD -p internal`
 
 Prepare a commit message. For each meaningful commit since the last tag, add
-a single line. Use `git show` on another release tag to see the format we use.
+a single line. See `git show proxy-init/v2.2.0` as an example the format we use.
 
 Note: currently `validator` doesn't rely on `internal`, while `cni-plugin` and
 `proxy-init` do.
 
 ## Step 2: Tag the release
 
-`git tag -a proxy-init/v2.2.0`
+First, find the current latest version tag for the subproject
+
+`git tag -l '<proxy-init | cni-plugin | validator>/*' --sort=-"v:refname" | head -n 1`
+
+Increase the version with a major, minor, or patch according to the changes made
+
+`git tag -a proxy-init/v2.x.x`
 
 For the commit message, use what you created in Step 1.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,16 +13,21 @@ The Tag identifier format is:
 ## Step 1: Prepare an appropriate log message for the release
 
 Take a look at the changes from the last release to now within the project
-subdirectory you're going to release from.
+subdirectory you're going to release from as well as `internal` if the project
+relies on code living there.
 
-`git log v2.0.0..HEAD -p proxy-init`
+`git log proxy-init/v2.1.0..HEAD -p proxy-init`
+`git log proxy-init/v2.1.0..HEAD -p internal`
 
 Prepare a commit message. For each meaningful commit since the last tag, add
 a single line. Use `git show` on another release tag to see the format we use.
 
+Note: currently `validator` doesn't rely on `internal`, while `cni-plugin` and
+`proxy-init` do.
+
 ## Step 2: Tag the release
 
-`git tag -a proxy-init/v2.1.0`
+`git tag -a proxy-init/v2.2.0`
 
 For the commit message, use what you created in Step 1.
 
@@ -30,7 +35,7 @@ For the commit message, use what you created in Step 1.
 
 By default in git, tags are local so we'll need to push the tag to `origin`.
 
-`git push origin proxy-init/v2.1.0`
+`git push origin proxy-init/v2.2.0`
 
 There you go, a release should be running in github, you can check the Actions
 page.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,7 +29,7 @@ Note: currently `validator` doesn't rely on `internal`, while `cni-plugin` and
 
 First, find the current latest version tag for the subproject
 
-`git tag -l '<proxy-init | cni-plugin | validator>/*' --sort=-"v:refname" | head -n 1`
+`git tag -l 'proxy-init/*' --sort=-"v:refname" | head -n 1`
 
 Increase the version with a major, minor, or patch according to the changes made
 


### PR DESCRIPTION
Remind ourselves to look at `internal` and some version bumps to improve the narrative flow of the document.

Signed-off-by: Steve Jenson <stevej@buoyant.io>