### PR TITLE
linkerd-cni: add support for skip-subnets annotation

### DIFF
--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -49,6 +49,7 @@ type ProxyInit struct {
 	PortsToRedirect       []int    `json:"ports-to-redirect"`
 	InboundPortsToIgnore  []string `json:"inbound-ports-to-ignore"`
 	OutboundPortsToIgnore []string `json:"outbound-ports-to-ignore"`
+	SubnetsToIgnore       []string `json:"subnets-to-ignore"`
 	Simulate              bool     `json:"simulate"`
 	UseWaitFlag           bool     `json:"use-wait-flag"`
 }
@@ -214,6 +215,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 				PortsToRedirect:       conf.ProxyInit.PortsToRedirect,
 				InboundPortsToIgnore:  conf.ProxyInit.InboundPortsToIgnore,
 				OutboundPortsToIgnore: conf.ProxyInit.OutboundPortsToIgnore,
+				SubnetsToIgnore:       conf.ProxyInit.SubnetsToIgnore,
 				SimulateOnly:          conf.ProxyInit.Simulate,
 				NetNs:                 args.Netns,
 				UseWaitFlag:           conf.ProxyInit.UseWaitFlag,
@@ -242,6 +244,18 @@ func cmdAdd(args *skel.CmdArgs) error {
 			if inboundSkipOverride != "" {
 				logEntry.Debugf("linkerd-cni: overriding InboundPortsToIgnore to %s", inboundSkipOverride)
 				options.InboundPortsToIgnore = strings.Split(inboundSkipOverride, ",")
+			}
+
+			// Check if there are any subnets to skip
+			subnetSkipOverride, err := getAnnotationOverride(ctx, client, pod, "config.linkerd.io/skip-subnets")
+			if err != nil {
+				logEntry.Errorf("linkerd-cni: could not retrieve overridden annotations: %s", err)
+				return err
+			}
+
+			if subnetSkipOverride != "" {
+				logEntry.Debugf("linkerd-cni: overriding SubnetsToIgnore to %s", subnetSkipOverride)
+				options.SubnetsToIgnore = strings.Split(subnetSkipOverride, ",")
 			}
 
 			// Override ProxyUID from annotations.

--- a/proxy-init/cmd/root.go
+++ b/proxy-init/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -115,11 +116,15 @@ func BuildFirewallConfiguration(options *RootOptions) (*iptables.FirewallConfigu
 		return nil, fmt.Errorf("--outgoing-proxy-port must be a valid TCP port number")
 	}
 
+	sanitizedSubnets := []string{}
 	for _, subnet := range options.SubnetsToIgnore {
+		subnet := strings.TrimSpace(subnet)
 		_, _, err := net.ParseCIDR(subnet)
 		if err != nil {
 			return nil, fmt.Errorf("%s is not a valid CIDR address", subnet)
 		}
+
+		sanitizedSubnets = append(sanitizedSubnets, subnet)
 	}
 
 	firewallConfiguration := &iptables.FirewallConfiguration{
@@ -129,7 +134,7 @@ func BuildFirewallConfiguration(options *RootOptions) (*iptables.FirewallConfigu
 		PortsToRedirectInbound: options.PortsToRedirect,
 		InboundPortsToIgnore:   options.InboundPortsToIgnore,
 		OutboundPortsToIgnore:  options.OutboundPortsToIgnore,
-		SubnetsToIgnore:        options.SubnetsToIgnore,
+		SubnetsToIgnore:        sanitizedSubnets,
 		SimulateOnly:           options.SimulateOnly,
 		NetNs:                  options.NetNs,
 		UseWaitFlag:            options.UseWaitFlag,


### PR DESCRIPTION
When using the proxy-init container, one can set the pod annotation `config.linkerd.io/skip-subnets` to instruct proxy-init to skip certain subnets during the setup. Unfortunately, this annotation is silently ignored when using the CNI plugin.

Fixes linkerd/linkerd2#9565