### PR TITLE
tests cilium interop with linkerd-cni

### DIFF
--- a/.github/workflows/cni-plugin-integration.yml
+++ b/.github/workflows/cni-plugin-integration.yml
@@ -28,3 +28,12 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Run CNI integration tests
         run: just cni-plugin-test-integration-calico
+cni-cilium-test:
+    continue-on-error: true
+    timeout-minutes: 15
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: linkerd/dev/actions/setup-tools@v39
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - name: Run CNI integration tests
+        run: just cni-plugin-test-integration-cilium

--- a/.github/workflows/cni-plugin-integration.yml
+++ b/.github/workflows/cni-plugin-integration.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Run CNI integration tests
         run: just cni-plugin-test-integration-calico
-cni-cilium-test:
+  cni-cilium-test:
     continue-on-error: true
     timeout-minutes: 15
     runs-on: ubuntu-20.04

--- a/cni-plugin/integration/manifests/cilium/linkerd-cni.yaml
+++ b/cni-plugin/integration/manifests/cilium/linkerd-cni.yaml
@@ -1,0 +1,173 @@
+##
+## Everything below here is generated from the output `linkerd install-cni`
+## and modified with the test image of the cni-plugin.
+##
+## Log level is set to debug to simplify development.
+##
+## DO NOT hand edit.
+##
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: linkerd-cni
+  labels:
+    linkerd.io/cni-resource: "true"
+    config.linkerd.io/admission-webhooks: disabled
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: linkerd-cni
+  namespace: linkerd-cni
+  labels:
+    linkerd.io/cni-resource: "true"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-cni
+  labels:
+    linkerd.io/cni-resource: "true"
+rules:
+- apiGroups: [""]
+  resources: ["pods", "nodes", "namespaces", "services"]
+  verbs: ["list", "get", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-cni
+  labels:
+    linkerd.io/cni-resource: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linkerd-cni
+subjects:
+- kind: ServiceAccount
+  name: linkerd-cni
+  namespace: linkerd-cni
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: linkerd-cni-config
+  namespace: linkerd-cni
+  labels:
+    linkerd.io/cni-resource: "true"
+data:
+  dest_cni_net_dir: "/etc/cni/net.d"
+  dest_cni_bin_dir: "/opt/cni/bin"
+  # The CNI network configuration to install on each node. The special
+  # values in this config will be automatically populated.
+  cni_network_config: |-
+    {
+      "name": "linkerd-cni",
+      "type": "linkerd-cni",
+      "log_level": "debug",
+      "policy": {
+          "type": "k8s",
+          "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+          "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+      },
+      "kubernetes": {
+          "kubeconfig": "__KUBECONFIG_FILEPATH__"
+      },
+      "linkerd": {
+        "incoming-proxy-port": 4143,
+        "outgoing-proxy-port": 4140,
+        "proxy-uid": 2102,
+        "ports-to-redirect": [],
+        "inbound-ports-to-ignore": ["4191","4190"],
+        "simulate": false,
+        "use-wait-flag": false
+      }
+    }
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: linkerd-cni
+  namespace: linkerd-cni
+  labels:
+    k8s-app: linkerd-cni
+    linkerd.io/cni-resource: "true"
+  annotations:
+    linkerd.io/created-by: linkerd/cli edge-22.12.1
+spec:
+  selector:
+    matchLabels:
+      k8s-app: linkerd-cni
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: linkerd-cni
+      annotations:
+        linkerd.io/created-by: linkerd/cli edge-22.12.1
+        linkerd.io/cni-resource: "true"
+        linkerd.io/inject: disabled
+    spec:
+      tolerations:
+        - operator: Exists
+      nodeSelector:
+        kubernetes.io/os: linux
+      hostNetwork: true
+      serviceAccountName: linkerd-cni
+      containers:
+      # This container installs the linkerd CNI binaries
+      # and CNI network config file on each node. The install
+      # script copies the files into place and then sleeps so
+      # that Kubernetes doesn't keep trying to restart it.
+      - name: install-cni
+        image: test.l5d.io/linkerd/cni-plugin:test
+        #image: cr.l5d.io/linkerd/cni-plugin:edge-22.12.1
+        env:
+        - name: DEST_CNI_NET_DIR
+          valueFrom:
+            configMapKeyRef:
+              name: linkerd-cni-config
+              key: dest_cni_net_dir
+        - name: DEST_CNI_BIN_DIR
+          valueFrom:
+            configMapKeyRef:
+              name: linkerd-cni-config
+              key: dest_cni_bin_dir
+        - name: CNI_NETWORK_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              name: linkerd-cni-config
+              key: cni_network_config
+        - name: SLEEP
+          value: "true"
+        lifecycle:
+          # In some edge-cases this helps ensure that cleanup() is called in the container's script
+          # https://github.com/linkerd/linkerd2/issues/2355
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - kill -15 1; sleep 15s
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /host/etc/cni/net.d
+          name: cni-net-dir
+        - mountPath: /tmp
+          name: linkerd-tmp-dir
+        securityContext:
+          readOnlyRootFilesystem: true
+          privileged:
+      volumes:
+      - name: cni-bin-dir
+        hostPath:
+          path: /opt/cni/bin
+      - name: cni-net-dir
+        hostPath:
+          path: /etc/cni/net.d
+      - name: linkerd-tmp-dir
+        emptyDir: {}

--- a/cni-plugin/integration/run.sh
+++ b/cni-plugin/integration/run.sh
@@ -96,7 +96,7 @@ k run linkerd-proxy \
 
 echo 'PASS: Network Validator'
 
-calico_overrides="{
+generic_config_mount="{
                \"apiVersion\": \"v1\",
                \"spec\": {
                   \"containers\": [
@@ -123,7 +123,7 @@ calico_overrides="{
                },
                \"status\": {}
             }"
-flannel_overrides="{
+flannel_config_mount="{
                \"apiVersion\": \"v1\",
                \"spec\": {
                   \"containers\": [
@@ -151,7 +151,6 @@ flannel_overrides="{
                \"status\": {}
             }"
 # This needs to use the name linkerd-proxy so that linkerd-cni will run.
-# We use the calico overrides for cilium to avoid duplication.
 echo '# Running tester...'
 if [ "$SCENARIO" == "calico" ] || [ "$SCENARIO" == "cilium" ]; then
   k run linkerd-proxy \
@@ -160,7 +159,7 @@ if [ "$SCENARIO" == "calico" ] || [ "$SCENARIO" == "cilium" ]; then
           --image-pull-policy=Never \
           --namespace=cni-plugin-test \
           --restart=Never \
-          --overrides="$calico_overrides" \
+          --overrides="$generic_config_mount" \
           --rm
 else
   k run linkerd-proxy \
@@ -169,6 +168,6 @@ else
           --image-pull-policy=Never \
           --namespace=cni-plugin-test \
           --restart=Never \
-          --overrides="$flannel_overrides" \
+          --overrides="$flannel_config_mount" \
           --rm
 fi

--- a/cni-plugin/integration/run.sh
+++ b/cni-plugin/integration/run.sh
@@ -72,7 +72,6 @@ create_test_lab
 if [ "$SCENARIO" == "calico" ]; then
   wait_rollout "deploy/calico-kube-controllers" "kube-system" "2m"
   wait_rollout "daemonset/calico-node" "kube-system" "2m"
-
 fi
 
 # Wait for linkerd-cni daemonset to complete
@@ -152,8 +151,9 @@ flannel_overrides="{
                \"status\": {}
             }"
 # This needs to use the name linkerd-proxy so that linkerd-cni will run.
+# We use the calico overrides for cilium to avoid duplication.
 echo '# Running tester...'
-if [ "$SCENARIO" == "calico" ]; then
+if [ "$SCENARIO" == "calico" ] || [ "$SCENARIO" == "cilium" ]; then
   k run linkerd-proxy \
           --attach \
           --image="test.l5d.io/linkerd/cni-plugin-tester:test" \

--- a/cni-plugin/integration/tests/cilium/cilium_test.go
+++ b/cni-plugin/integration/tests/cilium/cilium_test.go
@@ -1,0 +1,27 @@
+package cilium
+
+import (
+	"os"
+	"testing"
+
+	"github.com/linkerd/linkerd2-proxy-init/cni-plugin/integration/testutil"
+)
+
+const (
+	// ConfigDirectory = "/var/lib/rancher/k3s/agent/etc/cni/net.d"
+	ConfigDirectory = "/host/etc/cni/net.d"
+	CiliumConflist  = "05-cilium.conflist"
+)
+
+var runner *testutil.TestRunner
+
+func TestMain(m *testing.M) {
+	runner = testutil.NewTestRunner(ConfigDirectory, CiliumConflist)
+	os.Exit(m.Run())
+}
+
+func TestLinkerdIsLastCNIPlugin(t *testing.T) {
+	if err := runner.CheckCNIPluginIsLast(); err != nil {
+		t.Fatalf("Unexpected error: %e", err)
+	}
+}

--- a/cni-plugin/integration/tests/cilium/cilium_test.go
+++ b/cni-plugin/integration/tests/cilium/cilium_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	// ConfigDirectory = "/var/lib/rancher/k3s/agent/etc/cni/net.d"
 	ConfigDirectory = "/host/etc/cni/net.d"
 	CiliumConflist  = "05-cilium.conflist"
 )

--- a/justfile
+++ b/justfile
@@ -210,7 +210,6 @@ _cni-plugin-setup-cilium:
         --set bpf.masquerade=false \
         --set image.pullPolicy=IfNotPresent \
         --set ipam.mode=kubernetes
-    docker exec k3d-l5d-cilium-test-server-0 mount --make-shared /run/cilium/cgroupv2
     echo "cilium has been installed"
 
 # Run cni-plugin integration tests using flannel, in a dedicated k3d

--- a/justfile
+++ b/justfile
@@ -193,11 +193,11 @@ cni-plugin-test-integration-cilium:
 _cni-plugin-setup-cilium:
     #!/usr/bin/env bash
     set -euxo pipefail
-    docker exec -it k3d-l5d-cilium-test-server-0 mount bpffs /sys/fs/bpf -t bpf
-    docker exec -it k3d-l5d-cilium-test-server-0 mount --make-shared /sys/fs/bpf
-    docker exec -it k3d-l5d-cilium-test-server-0 mkdir -p /run/cilium/cgroupv2
-    docker exec -it k3d-l5d-cilium-test-server-0 mount -t cgroup2 none /run/cilium/cgroupv2
-    docker exec -it k3d-l5d-cilium-test-server-0 mount --make-shared /run/cilium/cgroupv2/
+    docker exec k3d-l5d-cilium-test-server-0 mount bpffs /sys/fs/bpf -t bpf
+    docker exec k3d-l5d-cilium-test-server-0 mount --make-shared /sys/fs/bpf
+    docker exec k3d-l5d-cilium-test-server-0 mkdir -p /run/cilium/cgroupv2
+    docker exec k3d-l5d-cilium-test-server-0 mount -t cgroup2 none /run/cilium/cgroupv2
+    docker exec k3d-l5d-cilium-test-server-0 mount --make-shared /run/cilium/cgroupv2/
     echo "Mounted /sys/fs/bpf to cilium-test-server cluster"
     helm repo add cilium https://helm.cilium.io/
     helm install cilium cilium/cilium --version 1.13.0 \
@@ -210,7 +210,7 @@ _cni-plugin-setup-cilium:
         --set bpf.masquerade=false \
         --set image.pullPolicy=IfNotPresent \
         --set ipam.mode=kubernetes
-    docker exec -it k3d-l5d-cilium-test-server-0 mount --make-shared /run/cilium/cgroupv2
+    docker exec k3d-l5d-cilium-test-server-0 mount --make-shared /run/cilium/cgroupv2
     echo "cilium has been installed"
 
 # Run cni-plugin integration tests using flannel, in a dedicated k3d

--- a/justfile
+++ b/justfile
@@ -156,7 +156,7 @@ build-cni-plugin-test-image *args='--load':
 # To run all scenarios see: `cni-plugin-test-integration-all`
 cni-plugin-test-integration: _cni-plugin-test-integration-deps _cni-plugin-test-integration
 
-# An alternate path is needed here so we can insert the cilium-specific setup
+# An alternate target is needed here so we can insert cilium-specific setup
 cni-plugin-test-integration-with-cilium: _cni-plugin-test-integration-deps _cni-plugin-setup-cilium _cni-plugin-test-integration
 
 # Run all integration test scenarios, in different environments
@@ -188,8 +188,6 @@ cni-plugin-test-integration-cilium:
         K3D_CREATE_FLAGS='{{ _K3D_CREATE_FLAGS_NO_CNI_NO_POLICY_ENFORCER }}' \
         cni-plugin-test-integration-with-cilium
 
-# This relies on a new cluster being setup as the default cluster as we'll be installing
-# things into kube-system
 _cni-plugin-setup-cilium:
     #!/usr/bin/env bash
     set -euxo pipefail


### PR DESCRIPTION
We add cilium to the mix!

Adds the following: 
* justfile targets for running a cilium installer and special fs setup
* test runner for checking that the config file is ok
* workflow integration for CI