### PR TITLE
Fix validator version check in release workflow

### DIFF
--- a/.github/workflows/release-validator.yml
+++ b/.github/workflows/release-validator.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           version=$(just validator --evaluate version)
           # shellcheck disable=SC2193
-          if [[ "v${version}" != '${{ steps.meta.outputs.version }}' ]]; then
+          if [[ "${version}" != '${{ steps.meta.outputs.version }}' ]]; then
             echo "::error ::Crate version v${version} does not match tag ${{ steps.meta.outputs.version }}"
             exit 1
           fi


### PR DESCRIPTION
`just validator --evaluate version` already returns the version prepended with `v`, so no need to include it in the check `if [[ "v${version}" != 'v0.1.2' ]]`