### PR TITLE
cni: use `scratch` as the base runtime docker image

### DIFF
--- a/Dockerfile-cni-plugin
+++ b/Dockerfile-cni-plugin
@@ -17,25 +17,25 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on \
     go build -o /go/bin/linkerd-cni -mod=readonly -ldflags "-s -w" -v ./cni-plugin/
 
 ##
-## Runtime
+## Runtime dependencies
 ##
 
 FROM debian:bullseye-slim as deps
 WORKDIR /linkerd
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    iptables \
     inotify-tools \
     procps \
     jq && \
     rm -rf /var/lib/apt/lists/*
 
-# We still rely on old iptables-legacy syntax.
+##
+## Runtime
+##
+
 FROM scratch as runtime
 COPY --from=deps /usr/bin/inotifywait /usr/bin/inotifywait
 COPY --from=deps /usr/bin/pgrep /usr/bin/pgrep
 COPY --from=deps /usr/bin/jq /usr/bin/jq
-COPY --from=deps /usr/sbin/iptables-legacy /usr/sbin/iptables
-COPY --from=deps /usr/sbin/ip6tables-legacy /usr/sbin/ip6tables
 COPY --from=go /go/bin/linkerd-cni /opt/cni/bin/
 COPY LICENSE .
 COPY cni-plugin/deployment/scripts/install-cni.sh .


### PR DESCRIPTION
Currently, the CNI plugin Docker image uses a Debian base image at runtime. Debian is used to install some packages that are dependencies of the `install-cni.sh` script, namely `inotifywatch`, `jq`, and `pgrep`. However, these packages are the only things we need, and it's not strictly necessary to run the CNI plugin in an entire Debian install. We could install these tools from a Debian image, and then actually run in a `scratch` image.

This branch changes the CNI plugin `Dockerfile` to use a `scratch` base image for the final runtime layer. `debian:bullseye-slim` is still used when building the image, in order to install the required packages using APT, and then the installed binaries are copied into the final image.

This is the same change as linkerd/linkerd2#10845, but applied to the dockerfile in this repo instead.