### PR TITLE
cni: change base runtime image from `scratch` to `alpine`

### DIFF
--- a/Dockerfile-cni-plugin
+++ b/Dockerfile-cni-plugin
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on \
 ## Runtime
 ##
 
-FROM --platform=$TARGETPLATFORM alpine:3.17.3 as runtime
+FROM --platform=$TARGETPLATFORM alpine:3.18.0 as runtime
 WORKDIR /linkerd
 RUN apk add \
     # For inotifywait

--- a/Dockerfile-cni-plugin
+++ b/Dockerfile-cni-plugin
@@ -27,6 +27,7 @@ RUN apk add \
     inotify-tools \
     # For pgrep
     procps \
+    bash \
     jq
 
 COPY --from=go /go/bin/linkerd-cni /opt/cni/bin/

--- a/Dockerfile-cni-plugin
+++ b/Dockerfile-cni-plugin
@@ -20,13 +20,13 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on \
 ## Runtime
 ##
 
-FROM --platform=$TARGETPLATFORM alpine:3.18.0 as runtime
+FROM --platform=$TARGETPLATFORM alpine:3.17.3 as runtime
 WORKDIR /linkerd
 RUN apk add \
     # For inotifywait
     inotify-tools \
     # For pgrep
-    procps-ng \
+    procps \
     jq
 
 COPY --from=go /go/bin/linkerd-cni /opt/cni/bin/

--- a/Dockerfile-cni-plugin
+++ b/Dockerfile-cni-plugin
@@ -17,25 +17,18 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on \
     go build -o /go/bin/linkerd-cni -mod=readonly -ldflags "-s -w" -v ./cni-plugin/
 
 ##
-## Runtime dependencies
-##
-
-FROM debian:bullseye-slim as deps
-WORKDIR /linkerd
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    inotify-tools \
-    procps \
-    jq && \
-    rm -rf /var/lib/apt/lists/*
-
-##
 ## Runtime
 ##
 
-FROM scratch as runtime
-COPY --from=deps /usr/bin/inotifywait /usr/bin/inotifywait
-COPY --from=deps /usr/bin/pgrep /usr/bin/pgrep
-COPY --from=deps /usr/bin/jq /usr/bin/jq
+FROM --platform=$TARGETPLATFORM alpine:3.17.3 as runtime
+WORKDIR /linkerd
+RUN apk add \
+    # For inotifywait
+    inotify-tools \
+    # For pgrep
+    procps-ng \
+    jq
+
 COPY --from=go /go/bin/linkerd-cni /opt/cni/bin/
 COPY LICENSE .
 COPY cni-plugin/deployment/scripts/install-cni.sh .


### PR DESCRIPTION
PR #237 changed the base runtime image for the CNI init container from `debian:bullseye-slim` to `scratch`, in the hopes of reducing the dependency footprint of that image. Unfortunately, it turns out that this breaks the CNI init container, since it must execute shell scripts and therefore requires a shell (specifically, `bash`), which does not exist in the `scratch` image. This was not detected by CI in this repo on PR #237, because it turns out that the CI jobs don't actually try to run the CNI init container. Instead, we didn't discover that this breaks stuff until the change was fully integrated in linkerd/linkerd2#10855.

This commit changes the base runtime image again, to `alpine:3.17.3`, similarly to the proxy-init dockerfile. We now install the necessary dependencies using `apk add` in the alpine layer. This way, we should have a shell, and be able to run the install script again.