### PR TITLE
feat: add group ID option

### DIFF
--- a/cni-plugin/deployment/linkerd-cni.conf.default
+++ b/cni-plugin/deployment/linkerd-cni.conf.default
@@ -14,6 +14,7 @@
         "incoming-proxy-port": 4143,
         "outgoing-proxy-port": 4140,
         "proxy-uid": 2102,
+        "proxy-gid": 2102,
         "ports-to-redirect": [],
         "inbound-ports-to-ignore": [],
         "outbound-ports-to-ignore": [],

--- a/cni-plugin/integration/manifests/calico/linkerd-cni.yaml
+++ b/cni-plugin/integration/manifests/calico/linkerd-cni.yaml
@@ -77,6 +77,7 @@ data:
         "incoming-proxy-port": 4143,
         "outgoing-proxy-port": 4140,
         "proxy-uid": 2102,
+        "proxy-gid": 2102,
         "ports-to-redirect": [],
         "inbound-ports-to-ignore": ["4191","4190"],
         "simulate": false,

--- a/cni-plugin/integration/manifests/cilium/linkerd-cni.yaml
+++ b/cni-plugin/integration/manifests/cilium/linkerd-cni.yaml
@@ -77,6 +77,7 @@ data:
         "incoming-proxy-port": 4143,
         "outgoing-proxy-port": 4140,
         "proxy-uid": 2102,
+        "proxy-gid": 2102,
         "ports-to-redirect": [],
         "inbound-ports-to-ignore": ["4191","4190"],
         "simulate": false,

--- a/cni-plugin/integration/manifests/flannel/linkerd-cni.yaml
+++ b/cni-plugin/integration/manifests/flannel/linkerd-cni.yaml
@@ -81,6 +81,7 @@ data:
         "incoming-proxy-port": 4143,
         "outgoing-proxy-port": 4140,
         "proxy-uid": 2102,
+        "proxy-gid": 2102,
         "ports-to-redirect": [],
         "inbound-ports-to-ignore": ["4191","4190"],
         "simulate": false,

--- a/cni-plugin/integration/testutil/test_util.go
+++ b/cni-plugin/integration/testutil/test_util.go
@@ -46,6 +46,7 @@ type ProxyInit struct {
 	IncomingProxyPort     int      `json:"incoming-proxy-port"`
 	OutgoingProxyPort     int      `json:"outgoing-proxy-port"`
 	ProxyUID              int      `json:"proxy-uid"`
+	ProxyGID              int      `json:"proxy-gid"`
 	PortsToRedirect       []int    `json:"ports-to-redirect"`
 	InboundPortsToIgnore  []string `json:"inbound-ports-to-ignore"`
 	OutboundPortsToIgnore []string `json:"outbound-ports-to-ignore"`
@@ -73,6 +74,7 @@ type LinkerdPlugin struct {
 //	   "incoming-proxy-port": 4143,
 //	   "outgoing-proxy-port": 4140,
 //	   "proxy-uid": 2102,
+//	   "proxy-gid": 2102,
 //	   "ports-to-redirect": [],
 //	   "inbound-ports-to-ignore": ["4191","4190"],
 //	   "simulate": false,
@@ -111,6 +113,11 @@ func checkLinkerdCniConf(plugin map[string]any) error {
 	proxyUID := proxyInit.ProxyUID
 	if proxyUID != 2102 {
 		return fmt.Errorf("proxy-uid has wrong value, expected: %v, found: %v", 2102, proxyUID)
+	}
+
+	proxyGID := proxyInit.ProxyGID
+	if proxyGID != 2102 {
+		return fmt.Errorf("proxy-gid has wrong value, expected: %v, found: %v", 2102, proxyUID)
 	}
 
 	simulate := proxyInit.Simulate

--- a/proxy-init/cmd/root.go
+++ b/proxy-init/cmd/root.go
@@ -34,6 +34,7 @@ type RootOptions struct {
 	IncomingProxyPort     int
 	OutgoingProxyPort     int
 	ProxyUserID           int
+	ProxyGroupID          int
 	PortsToRedirect       []int
 	InboundPortsToIgnore  []string
 	OutboundPortsToIgnore []string
@@ -55,6 +56,7 @@ func newRootOptions() *RootOptions {
 		IncomingProxyPort:     -1,
 		OutgoingProxyPort:     -1,
 		ProxyUserID:           -1,
+		ProxyGroupID:          -1,
 		PortsToRedirect:       make([]int, 0),
 		InboundPortsToIgnore:  make([]string, 0),
 		OutboundPortsToIgnore: make([]string, 0),
@@ -134,6 +136,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.PersistentFlags().IntVarP(&options.IncomingProxyPort, "incoming-proxy-port", "p", options.IncomingProxyPort, "Port to redirect incoming traffic")
 	cmd.PersistentFlags().IntVarP(&options.OutgoingProxyPort, "outgoing-proxy-port", "o", options.OutgoingProxyPort, "Port to redirect outgoing traffic")
 	cmd.PersistentFlags().IntVarP(&options.ProxyUserID, "proxy-uid", "u", options.ProxyUserID, "User ID that the proxy is running under. Any traffic coming from this user will be ignored to avoid infinite redirection loops.")
+	cmd.PersistentFlags().IntVarP(&options.ProxyGroupID, "proxy-gid", "g", options.ProxyGroupID, "Group ID that the proxy is running under. Any traffic coming from this group will be ignored to avoid infinite redirection loops.")
 	cmd.PersistentFlags().IntSliceVarP(&options.PortsToRedirect, "ports-to-redirect", "r", options.PortsToRedirect, "Port to redirect to proxy, if no port is specified then ALL ports are redirected")
 	cmd.PersistentFlags().StringSliceVar(&options.InboundPortsToIgnore, "inbound-ports-to-ignore", options.InboundPortsToIgnore, "Inbound ports and/or port ranges (inclusive) to ignore and not redirect to proxy. This has higher precedence than any other parameters.")
 	cmd.PersistentFlags().StringSliceVar(&options.OutboundPortsToIgnore, "outbound-ports-to-ignore", options.OutboundPortsToIgnore, "Outbound ports and/or port ranges (inclusive) to ignore and not redirect to proxy. This has higher precedence than any other parameters.")
@@ -195,6 +198,7 @@ func BuildFirewallConfiguration(options *RootOptions) (*iptables.FirewallConfigu
 		ProxyInboundPort:       options.IncomingProxyPort,
 		ProxyOutgoingPort:      options.OutgoingProxyPort,
 		ProxyUID:               options.ProxyUserID,
+		ProxyGID:               options.ProxyGroupID,
 		PortsToRedirectInbound: options.PortsToRedirect,
 		InboundPortsToIgnore:   options.InboundPortsToIgnore,
 		OutboundPortsToIgnore:  options.OutboundPortsToIgnore,

--- a/proxy-init/cmd/root_test.go
+++ b/proxy-init/cmd/root_test.go
@@ -12,6 +12,7 @@ func TestBuildFirewallConfiguration(t *testing.T) {
 		expectedIncomingProxyPort := 1234
 		expectedOutgoingProxyPort := 2345
 		expectedProxyUserID := 33
+		expectedProxyGroupID := 33
 		expectedConfig := &iptables.FirewallConfiguration{
 			Mode:                   iptables.RedirectAllMode,
 			PortsToRedirectInbound: make([]int, 0),
@@ -21,6 +22,7 @@ func TestBuildFirewallConfiguration(t *testing.T) {
 			ProxyInboundPort:       expectedIncomingProxyPort,
 			ProxyOutgoingPort:      expectedOutgoingProxyPort,
 			ProxyUID:               expectedProxyUserID,
+			ProxyGID:               expectedProxyGroupID,
 			SimulateOnly:           false,
 			UseWaitFlag:            false,
 			BinPath:                "iptables-legacy",
@@ -32,6 +34,7 @@ func TestBuildFirewallConfiguration(t *testing.T) {
 		options.OutgoingProxyPort = expectedOutgoingProxyPort
 		options.ProxyUserID = expectedProxyUserID
 		options.IPv6 = false
+		options.ProxyGroupID = expectedProxyGroupID
 
 		config, err := BuildFirewallConfiguration(options)
 		if err != nil {

--- a/proxy-init/integration/iptables/iptablestest-lab.yaml
+++ b/proxy-init/integration/iptables/iptablestest-lab.yaml
@@ -73,7 +73,7 @@ spec:
   - name: iptables-test
     image: test.l5d.io/linkerd/proxy-init:test
     imagePullPolicy: Never
-    args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102"]
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -90,7 +90,7 @@ spec:
   - name: linkerd-init
     image: test.l5d.io/linkerd/proxy-init:test
     imagePullPolicy: Never
-    args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102"]
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -144,7 +144,7 @@ spec:
   - name: linkerd-init
     image: test.l5d.io/linkerd/proxy-init:test
     imagePullPolicy: Never
-    args: ["-p", "8080",  "-o", "8080", "-u", "2102"]
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102"]
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -201,7 +201,7 @@ spec:
   - name: linkerd-init
     image: test.l5d.io/linkerd/proxy-init:test
     imagePullPolicy: Never
-    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-r", "9090", "-r", "9099"]
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102", "-r", "9090", "-r", "9099"]
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -264,7 +264,7 @@ spec:
   - name: linkerd-init
     image: test.l5d.io/linkerd/proxy-init:test
     imagePullPolicy: Never
-    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "--inbound-ports-to-ignore", "6000-8000"]
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102", "--inbound-ports-to-ignore", "6000-8000"]
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -318,7 +318,7 @@ spec:
   - name: linkerd-init
     image: test.l5d.io/linkerd/proxy-init:test
     imagePullPolicy: Never
-    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "--subnets-to-ignore", "0.0.0.0/0"]
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102", "--subnets-to-ignore", "0.0.0.0/0"]
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:


### PR DESCRIPTION
The intention is to make group IDs configurable. I opened [an issue](https://github.com/linkerd/linkerd2/issues/11773) in order to target this. Before working on the respective changes in the linkerd2 repo I thought it would make sense to get this feature implemented here first.

This pull request adds the option to set the group ID via command line and via annotation. The tests available via `just` ran successfully in the dev container and some manual tests also ran well. I had to tweak my setup a little bit in order to make it work in WSL2 behind an HTTP proxy, so my setup might differ from the reference setup. Still, I assume that my tweaks did not have an impact on the outcome of the tests. It is also worth mentioning that tweaking IP tables manually is not part of my daily business. I just mention it for the reviewers to pay special attention. Thanks in advance for the review. Looking forward to this feature getting merged.