### PR TITLE
Upgrade alpine, use iptables-legacy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on \
 ## Runtime
 ##
 
-FROM --platform=$TARGETPLATFORM alpine:3.18.5 as runtime
-RUN apk add iptables libcap && \
+FROM --platform=$TARGETPLATFORM alpine:3.19.0 as runtime
+RUN apk add iptables-legacy iptables libcap && \
     touch /run/xtables.lock && \
     chmod 0666 /run/xtables.lock
 

--- a/Dockerfile-cni-plugin
+++ b/Dockerfile-cni-plugin
@@ -34,7 +34,7 @@ RUN --mount=type=cache,target=target \
     just cni-repair-controller arch="$TARGETARCH" profile=release build && \
     mv "target/$target/release/linkerd-cni-repair-controller" .
 
-FROM --platform=$TARGETPLATFORM alpine:3.18.5 as runtime
+FROM --platform=$TARGETPLATFORM alpine:3.19.0 as runtime
 WORKDIR /linkerd
 RUN apk add \
     # For inotifywait

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -219,8 +219,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 				SimulateOnly:          conf.ProxyInit.Simulate,
 				NetNs:                 args.Netns,
 				UseWaitFlag:           conf.ProxyInit.UseWaitFlag,
-				FirewallBinPath:       "iptables",
-				FirewallSaveBinPath:   "iptables-save",
+				FirewallBinPath:       "iptables-legacy",
+				FirewallSaveBinPath:   "iptables-legacy-save",
 			}
 
 			// Check if there are any overridden ports to be skipped

--- a/proxy-init/cmd/root.go
+++ b/proxy-init/cmd/root.go
@@ -47,8 +47,8 @@ func newRootOptions() *RootOptions {
 		TimeoutCloseWaitSecs:  0,
 		LogFormat:             "plain",
 		LogLevel:              "info",
-		FirewallBinPath:       "iptables",
-		FirewallSaveBinPath:   "iptables-save",
+		FirewallBinPath:       "iptables-legacy",
+		FirewallSaveBinPath:   "iptables-legacy-save",
 	}
 }
 

--- a/proxy-init/cmd/root_test.go
+++ b/proxy-init/cmd/root_test.go
@@ -23,8 +23,8 @@ func TestBuildFirewallConfiguration(t *testing.T) {
 			ProxyUID:               expectedProxyUserID,
 			SimulateOnly:           false,
 			UseWaitFlag:            false,
-			BinPath:                "iptables",
-			SaveBinPath:            "iptables-save",
+			BinPath:                "iptables-legacy",
+			SaveBinPath:            "iptables-legacy-save",
 		}
 
 		options := newRootOptions()


### PR DESCRIPTION
PR #307 bumps alpine to 3.19.0. Unfortunately that version defaults to iptables-nft. This breaks an assumption in our Dockerfile and proxy-init that the `iptables` binary is the legacy version.

Bump alpine to 3.19.0, modify the Dockerfile to continue installing iptables-legacy, and modify the proxy-init command to default to iptables-legacy.