### PR TITLE
Fix linkerd-cni when using native sidecars

### DIFF
--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -192,14 +192,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 			return err
 		}
 
-		containsLinkerdProxy := false
-		for _, container := range pod.Spec.Containers {
-			if container.Name == "linkerd-proxy" {
-				containsLinkerdProxy = true
-				break
-			}
-		}
-
 		containsInitContainer := false
 		for _, container := range pod.Spec.InitContainers {
 			if container.Name == "linkerd-init" {
@@ -208,7 +200,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			}
 		}
 
-		if containsLinkerdProxy && !containsInitContainer {
+		if !containsInitContainer && containsLinkerdProxy(&pod.Spec) {
 			logEntry.Debugf("linkerd-cni: setting up iptables firewall for %s/%s", namespace, pod)
 			options := cmd.RootOptions{
 				IncomingProxyPort:     conf.ProxyInit.IncomingProxyPort,
@@ -343,6 +335,23 @@ func cmdCheck(_ *skel.CmdArgs) error {
 func cmdDel(_ *skel.CmdArgs) error {
 	logrus.Info("linkerd-cni: delete called but not implemented")
 	return nil
+}
+
+func containsLinkerdProxy(spec *v1.PodSpec) bool {
+	for _, container := range spec.Containers {
+		if container.Name == "linkerd-proxy" {
+			return true
+		}
+	}
+
+	// native sidecar proxy
+	for _, container := range spec.InitContainers {
+		if container.Name == "linkerd-proxy" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getAPIServerPorts(ctx context.Context, api *kubernetes.Clientset) ([]string, error) {


### PR DESCRIPTION
Fixes linkerd/linkerd2#11597

When the cni plugin is triggered, it validates that the proxy has been injected into the pod before setting up the iptables rules. It does so by looking for the "linkerd-proxy" container. However, when the proxy is injected as a native sidecar, it gets added as an _init_ container, so it was being disregarded here.

We don't have integration tests for validating native sidecars when using linkerd-cni because [Calico doesn't work in k3s since k8s 1.27](https://github.com/k3d-io/k3d/issues/1375), and we require k8s 1.29 for using native sidecars.
I did nevertheless successfully test this fix in an AKS cluster.