### PR TITLE
Fail container when ip6tables fails

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   proxy-init-integration:
-    continue-on-error: true
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:

--- a/cni-plugin/integration/manifests/calico/linkerd-cni.yaml
+++ b/cni-plugin/integration/manifests/calico/linkerd-cni.yaml
@@ -83,7 +83,7 @@ data:
         "simulate": false,
         "use-wait-flag": false,
         "iptables-mode": "$IPTABLES_MODE",
-        "ipv6": true
+        "ipv6": false
       }
     }
 ---

--- a/cni-plugin/integration/manifests/cilium/linkerd-cni.yaml
+++ b/cni-plugin/integration/manifests/cilium/linkerd-cni.yaml
@@ -83,7 +83,7 @@ data:
         "simulate": false,
         "use-wait-flag": false,
         "iptables-mode": "$IPTABLES_MODE",
-        "ipv6": true
+        "ipv6": false
       }
     }
 ---

--- a/cni-plugin/integration/manifests/flannel/linkerd-cni.yaml
+++ b/cni-plugin/integration/manifests/flannel/linkerd-cni.yaml
@@ -87,7 +87,7 @@ data:
         "simulate": false,
         "use-wait-flag": false,
         "iptables-mode": "$IPTABLES_MODE",
-        "ipv6": true
+        "ipv6": false
       }
     }
 ---

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -399,10 +399,7 @@ func buildAndConfigure(logEntry *logrus.Entry, options *cmd.RootOptions) error {
 		return err
 	}
 
-	err = iptables.ConfigureFirewall(*firewallConfiguration)
-	// We couldn't find a robust way of checking IPv6 support besides trying to just call ip6tables-save.
-	// If IPv4 rules worked but not IPv6, let's not fail the container (the actual problem will get logged).
-	if !options.IPv6 && err != nil {
+	if err := iptables.ConfigureFirewall(*firewallConfiguration); err != nil {
 		logEntry.Errorf("linkerd-cni: could not configure firewall: %s", err)
 		return err
 	}

--- a/proxy-init/cmd/root.go
+++ b/proxy-init/cmd/root.go
@@ -125,9 +125,9 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 
-			// We couldn't find a robust way of checking IPv6 support besides trying to just call ip6tables-save.
-			// If IPv4 rules worked but not IPv6, let's not fail the container (the actual problem will get logged).
-			_ = iptables.ConfigureFirewall(*config)
+			if err = iptables.ConfigureFirewall(*config); err != nil {
+				return err
+			}
 
 			return nil
 		},

--- a/proxy-init/integration/iptables/iptablestest-lab.yaml
+++ b/proxy-init/integration/iptables/iptablestest-lab.yaml
@@ -73,7 +73,7 @@ spec:
   - name: iptables-test
     image: test.l5d.io/linkerd/proxy-init:test
     imagePullPolicy: Never
-    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102"]
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102", "--ipv6=false"]
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -90,7 +90,7 @@ spec:
   - name: linkerd-init
     image: test.l5d.io/linkerd/proxy-init:test
     imagePullPolicy: Never
-    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102"]
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102", "--ipv6=false"]
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -144,7 +144,7 @@ spec:
   - name: linkerd-init
     image: test.l5d.io/linkerd/proxy-init:test
     imagePullPolicy: Never
-    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102"]
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102", "--ipv6=false"]
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -201,7 +201,7 @@ spec:
   - name: linkerd-init
     image: test.l5d.io/linkerd/proxy-init:test
     imagePullPolicy: Never
-    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102", "-r", "9090", "-r", "9099"]
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102", "-r", "9090", "-r", "9099", "--ipv6=false"]
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -264,7 +264,7 @@ spec:
   - name: linkerd-init
     image: test.l5d.io/linkerd/proxy-init:test
     imagePullPolicy: Never
-    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102", "--inbound-ports-to-ignore", "6000-8000"]
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102", "--inbound-ports-to-ignore", "6000-8000", "--ipv6=false"]
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -318,7 +318,7 @@ spec:
   - name: linkerd-init
     image: test.l5d.io/linkerd/proxy-init:test
     imagePullPolicy: Never
-    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102", "--subnets-to-ignore", "0.0.0.0/0"]
+    args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-g", "2102", "--subnets-to-ignore", "0.0.0.0/0", "--ipv6=false"]
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:


### PR DESCRIPTION
Fail container when ip6tables fails
    
Ignoring these failures can cause IPv6 traffic to bypass the proxy; i.e.
IPv6 traffic can work in a cluster but linkerd might not be configured
with the appropriate iptables flavor (nft or legacy) and so the rules
won't be set.
    
Back when we had IPv6 support enabled by default we still ran these
ip6tables rules in IPv4-only clusters and so ignored failures to avoid
breaking things unexpectedly. But now that IPv6 support is opt-in, we
should expect the cluster to provide a fully functional IPv6 stack and
linkerd is configured appropriately for it, and so fail early when
things don't work as expected.
    
This change also explicitly disables IPv6 in the integration tests.
