### PR TITLE
build(deps): bump linkerd/dev from v43 to v44

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "linkerd2",
-    "image": "ghcr.io/linkerd/dev:v43",
+    "image": "ghcr.io/linkerd/dev:v44",
     "extensions": [
         "DavidAnson.vscode-markdownlint",
         "golang.go",

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v43
+      - uses: linkerd/dev/actions/setup-tools@v44
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: just action-lint
 
   devcontainer-versions:
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v43
+      - uses: linkerd/dev/actions/setup-tools@v44
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: just action-dev-check

--- a/.github/workflows/cni-plugin-integration.yml
+++ b/.github/workflows/cni-plugin-integration.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v43
+      - uses: linkerd/dev/actions/setup-tools@v44
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run CNI integration tests
         env:
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v43
+      - uses: linkerd/dev/actions/setup-tools@v44
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run CNI ordering tests
         run: just cni-plugin-test-ordering
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v43
+      - uses: linkerd/dev/actions/setup-tools@v44
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run repair-controller tests
         run: just cni-repair-controller-integration

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-go
+    container: ghcr.io/linkerd/dev:v44-go
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
@@ -22,7 +22,7 @@ jobs:
 
   fmt:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-go
+    container: ghcr.io/linkerd/dev:v44-go
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
@@ -30,7 +30,7 @@ jobs:
 
   unit-test:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-go
+    container: ghcr.io/linkerd/dev:v44-go
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v43
+      - uses: linkerd/dev/actions/setup-tools@v44
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run proxy-init integration tests
         run: just proxy-init-test-integration

--- a/.github/workflows/release-cni-plugin.yml
+++ b/.github/workflows/release-cni-plugin.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: cni-plugin-${{ needs.meta.outputs.mode }}-
 
       - uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
-      - uses: linkerd/dev/actions/setup-tools@v43
+      - uses: linkerd/dev/actions/setup-tools@v44
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: |
           just cni-plugin-image='${{ needs.meta.outputs.repo }}:${{ needs.meta.outputs.version }}' \

--- a/.github/workflows/release-proxy-init.yml
+++ b/.github/workflows/release-proxy-init.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: proxy-init-${{ needs.meta.outputs.mode }}-
 
       - uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
-      - uses: linkerd/dev/actions/setup-tools@v43
+      - uses: linkerd/dev/actions/setup-tools@v44
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: |
           just proxy-init-image='${{ needs.meta.outputs.repo }}:${{ needs.meta.outputs.version }}' \

--- a/.github/workflows/release-validator.yml
+++ b/.github/workflows/release-validator.yml
@@ -14,7 +14,7 @@ jobs:
   meta:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-rust
+    container: ghcr.io/linkerd/dev:v44-rust
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/version-mode
@@ -34,7 +34,7 @@ jobs:
         arch: [amd64, arm64, arm]
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-rust-musl
+    container: ghcr.io/linkerd/dev:v44-rust-musl
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: just validator arch=${{ matrix.arch }} profile=release version=${{ needs.meta.outputs.version }} package

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
   check:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-rust
+    container: ghcr.io/linkerd/dev:v44-rust
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: just rs-fetch

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -15,6 +15,6 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v43
+      - uses: linkerd/dev/actions/setup-tools@v44
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: just sh-lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,8 @@
 linters:
   enable:
+    # TODO - copyloopvar.
     - errcheck
     - errorlint
-    - exportloopref
     - goconst
     - gocritic
     - gosec
@@ -31,7 +31,6 @@ linters:
   # Disabled for generics https://github.com/golangci/golangci-lint/issues/2649
   disable:
     - bodyclose
-    - structcheck
     - unparam
 
 

--- a/cni-plugin/integration/Dockerfile-tester
+++ b/cni-plugin/integration/Dockerfile-tester
@@ -8,7 +8,7 @@
 #  1) a specific k3d cluster configured with CNI
 #  2) a test suite (e.g. `flannel.go`) runs with a configured CNI plugin.
 
-FROM golang:1.22-alpine as build
+FROM golang:1.23-alpine as build
 RUN apk add build-base
 ENV GOCACHE=/tmp/
 WORKDIR /src

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,4 @@
+[graph]
 targets = [
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "aarch64-unknown-linux-gnu" },
@@ -7,8 +8,11 @@ targets = [
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-yanked = "deny"
-ignore = []
+ignore = [
+    # Update kube to address unmaintained dependencies
+    "RUSTSEC-2024-0384",
+    "RUSTSEC-2024-0388",
+]
 
 [licenses]
 allow = ["Apache-2.0", "BSD-3-Clause", "ISC", "MIT"]
@@ -46,19 +50,12 @@ multiple-versions = "deny"
 # Wildcard dependencies are used for all workspace-local crates.
 wildcards = "allow"
 highlight = "all"
-deny = []
 skip = [
-    # `rustls-pemfile` and `k8s-openapi` depend on versions of `base64` that
-    # have diverged significantly.
-    { name = "base64" },
     # https://github.com/hawkw/matchers/pull/4
     { name = "regex-automata", version = "0.1" },
     { name = "regex-syntax", version = "0.6" },
     # syn v2 has been released and some libraries are slower to adopt it
     { name = "syn", version = "1.0" },
-    # recent tokio versions (v1.34) depend on socket2 v0.5.5 while hyper is
-    # stuck on v0.4.10
-    { name = "socket2" },
 ]
 skip-tree = [
     # `serde_json` and `h2` depend on diverged versions of `indexmap` (2.0.x and

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/linkerd/linkerd2-proxy-init
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.3
+toolchain go1.23.3
 
 require (
 	github.com/containernetworking/cni v1.2.3

--- a/proxy-init/integration/iptables/test_service/test_service.go
+++ b/proxy-init/integration/iptables/test_service/test_service.go
@@ -18,7 +18,7 @@ var (
 
 func returnHostAndPortHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Got request [%v] returning [%s]\n", r, response())
-	fmt.Fprintln(w, response())
+	_, _ = fmt.Fprintln(w, response())
 }
 
 func callOtherServiceHandler(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +35,7 @@ func callOtherServiceHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), 500)
 		} else {
 			response := fmt.Sprintf("me:[%s]downstream:[%s]", response(), strings.TrimSpace(string(body)))
-			fmt.Fprintln(w, response)
+			_, _ = fmt.Fprintln(w, response)
 		}
 	}
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.83.0"


### PR DESCRIPTION
* docker.io/library/golang from 1.22 to 1.23
* gotestsum from 0.4.2 to 1.12.0
* protoc-gen-go from 1.28.1 to 1.35.2
* protoc-gen-go-grpc from 1.2 to 1.5.1
* docker.io/library/rust from 1.76.0 to 1.83.0
* cargo-deny from 0.14.11 to 0.16.3
* cargo-nextest from 0.9.67 to 0.9.85
* cargo-tarpaulin from 0.27.3 to 0.31.3
* just from 1.24.0 to 1.37.0
* yq from 4.33.3 to 4.44.5
* markdownlint-cli2 from 0.10.0 to 0.15.0
* shellcheck from 0.9.0 to 0.10.0
* actionlint from 1.6.26 to 1.7.4
* protoc from 3.20.3 to 29.0
* step from 0.25.2 to 0.28.2
* kubectl from 1.29.2 to 1.31.3
* k3d from 5.6.0 to 5.7.5
* k3s image shas
* helm from 3.14.1 to 3.16.3
* helm-docs from 1.12.0 to 1.14.2