### PR TITLE
feat(linkerd-cni): add support for plain iptables commands

### DIFF
--- a/proxy-init/cmd/root.go
+++ b/proxy-init/cmd/root.go
@@ -18,22 +18,22 @@ const (
 	IPTablesModeLegacy = "legacy"
 	// IPTablesModeNFT signals the usage of the iptables-nft commands
 	IPTablesModeNFT = "nft"
-	// IPTablesModeDefault signals the usage of the iptables commands, which
+	// IPTablesModePlain signals the usage of the iptables commands, which
 	// can be either legacy or nft
-	IPTablesModeDefault = "default"
+	IPTablesModePlain = "plain"
 
-	cmdLegacy          = "iptables-legacy"
-	cmdLegacySave      = "iptables-legacy-save"
-	cmdLegacyIPv6      = "ip6tables-legacy"
-	cmdLegacyIPv6Save  = "ip6tables-legacy-save"
-	cmdNFT             = "iptables-nft"
-	cmdNFTSave         = "iptables-nft-save"
-	cmdNFTIPv6         = "ip6tables-nft"
-	cmdNFTIPv6Save     = "ip6tables-nft-save"
-	cmdDefault         = "iptables"
-	cmdDefaultSave     = "iptables-save"
-	cmdDefaultIPv6     = "ip6tables"
-	cmdDefaultIPv6Save = "ip6tables-save"
+	cmdLegacy         = "iptables-legacy"
+	cmdLegacySave     = "iptables-legacy-save"
+	cmdLegacyIPv6     = "ip6tables-legacy"
+	cmdLegacyIPv6Save = "ip6tables-legacy-save"
+	cmdNFT            = "iptables-nft"
+	cmdNFTSave        = "iptables-nft-save"
+	cmdNFTIPv6        = "ip6tables-nft"
+	cmdNFTIPv6Save    = "ip6tables-nft-save"
+	cmdPlain          = "iptables"
+	cmdPlainSave      = "iptables-save"
+	cmdPlainIPv6      = "ip6tables"
+	cmdPlainIPv6Save  = "ip6tables-save"
 )
 
 // RootOptions provides the information that will be used to build a firewall configuration.
@@ -154,7 +154,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.PersistentFlags().IntVar(&options.TimeoutCloseWaitSecs, "timeout-close-wait-secs", options.TimeoutCloseWaitSecs, "Sets nf_conntrack_tcp_timeout_close_wait")
 	cmd.PersistentFlags().StringVar(&options.LogFormat, "log-format", options.LogFormat, "Configure log format ('plain' or 'json')")
 	cmd.PersistentFlags().StringVar(&options.LogLevel, "log-level", options.LogLevel, "Configure log level")
-	cmd.PersistentFlags().StringVar(&options.IPTablesMode, "iptables-mode", options.IPTablesMode, "Variant of iptables command to use (\"legacy\", \"nft\" or \"default\"); overrides --firewall-bin-path and --firewall-save-bin-path")
+	cmd.PersistentFlags().StringVar(&options.IPTablesMode, "iptables-mode", options.IPTablesMode, "Variant of iptables command to use (\"legacy\", \"nft\" or \"plain\"); overrides --firewall-bin-path and --firewall-save-bin-path")
 	cmd.PersistentFlags().BoolVar(&options.IPv6, "ipv6", options.IPv6, "Set rules both via iptables and ip6tables to support dual-stack networking")
 
 	// these two flags are kept for backwards-compatibility, but --iptables-mode is preferred
@@ -165,8 +165,8 @@ func NewRootCmd() *cobra.Command {
 
 // BuildFirewallConfiguration returns an iptables FirewallConfiguration suitable to use to configure iptables.
 func BuildFirewallConfiguration(options *RootOptions) (*iptables.FirewallConfiguration, error) {
-	if options.IPTablesMode != "" && options.IPTablesMode != IPTablesModeLegacy && options.IPTablesMode != IPTablesModeNFT && options.IPTablesMode != IPTablesModeDefault {
-		return nil, fmt.Errorf("--iptables-mode valid values are only \"%s\", \"%s\" and \"%s\"", IPTablesModeLegacy, IPTablesModeNFT, IPTablesModeDefault)
+	if options.IPTablesMode != "" && options.IPTablesMode != IPTablesModeLegacy && options.IPTablesMode != IPTablesModeNFT && options.IPTablesMode != IPTablesModePlain {
+		return nil, fmt.Errorf("--iptables-mode valid values are only \"%s\", \"%s\" and \"%s\"", IPTablesModeLegacy, IPTablesModeNFT, IPTablesModePlain)
 	}
 
 	if options.IPTablesMode == "" {
@@ -175,10 +175,10 @@ func BuildFirewallConfiguration(options *RootOptions) (*iptables.FirewallConfigu
 			options.IPTablesMode = IPTablesModeLegacy
 		case cmdNFT:
 			options.IPTablesMode = IPTablesModeNFT
-		case cmdDefault:
-			options.IPTablesMode = IPTablesModeDefault
+		case cmdPlain:
+			options.IPTablesMode = IPTablesModePlain
 		default:
-			return nil, fmt.Errorf("--firewall-bin-path valid values are only \"%s\", \"%s\" and \"%s\"", cmdLegacy, cmdNFT, cmdDefault)
+			return nil, fmt.Errorf("--firewall-bin-path valid values are only \"%s\", \"%s\" and \"%s\"", cmdLegacy, cmdNFT, cmdPlain)
 		}
 	}
 
@@ -251,9 +251,9 @@ func getCommands(options *RootOptions) (string, string) {
 		return cmdNFT, cmdNFTSave
 	default:
 		if options.IPv6 {
-			return cmdDefaultIPv6, cmdDefaultIPv6Save
+			return cmdPlainIPv6, cmdPlainIPv6Save
 		}
-		return cmdDefault, cmdDefaultSave
+		return cmdPlain, cmdPlainSave
 	}
 }
 


### PR DESCRIPTION
Currently the `iptables-mode` for linkerd-cni admits the values `legacy` and `nft`, which make the plugin use the `iptables-legacy[-save]` and `iptables-nft[-save]` commands respectively.

This assumes those commands are available in the node environment, given that linkerd-cni is triggered by the kubelet.

We have found that not to be the case for RHEL, where by default only `iptables[-save]` is available, which is equivalent to the `iptables-nft[-save]` command in other enviroments.

To address this case, this change adds a new possible value `iptables-mode: default` that makes the plugin use the `iptables[-save]` commands.

This has been tested successfully using RKE2 deployed in RHEL 8.10.