### PR TITLE
test(deps): use setup-rust in cni-plugin-integration/repair-controller

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: linkerd/dev/actions/setup-tools@v45
@@ -20,7 +20,7 @@ jobs:
       - run: just action-lint
 
   devcontainer-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: linkerd/dev/actions/setup-tools@v45
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/cni-plugin-integration.yml
+++ b/.github/workflows/cni-plugin-integration.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v45
+      - uses: linkerd/dev/actions/setup-rust@v45
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run repair-controller tests
         run: just cni-repair-controller-integration

--- a/.github/workflows/cni-plugin-integration.yml
+++ b/.github/workflows/cni-plugin-integration.yml
@@ -19,7 +19,7 @@ jobs:
         cni: [flannel, calico, cilium]
         iptables-mode: [legacy, nft]
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: linkerd/dev/actions/setup-tools@v45
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -30,7 +30,7 @@ jobs:
   ordering-test:
     continue-on-error: true
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: linkerd/dev/actions/setup-tools@v45
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -38,7 +38,7 @@ jobs:
         run: just cni-plugin-test-ordering
   repair-controller:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: linkerd/dev/actions/setup-rust@v45
       - uses: linkerd/dev/actions/setup-tools@v45

--- a/.github/workflows/cni-plugin-integration.yml
+++ b/.github/workflows/cni-plugin-integration.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - .github/workflows/cni-plugin-integration.yml
       - Dockerfile-cni-plugin
       - cni-plugin/integration/flannel/Dockerfile-tester
       - cni-plugin/integration/run.sh

--- a/.github/workflows/cni-plugin-integration.yml
+++ b/.github/workflows/cni-plugin-integration.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: linkerd/dev/actions/setup-rust@v45
+      - uses: linkerd/dev/actions/setup-tools@v45
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run repair-controller tests
         run: just cni-repair-controller-integration

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ghcr.io/linkerd/dev:v44-go
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -21,7 +21,7 @@ jobs:
       - run: just go-lint --verbose --timeout=10m
 
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ghcr.io/linkerd/dev:v44-go
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -29,7 +29,7 @@ jobs:
       - run: just go-fmt-check
 
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ghcr.io/linkerd/dev:v44-go
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   proxy-init-integration:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: linkerd/dev/actions/setup-tools@v45
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   md-lint:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265

--- a/.github/workflows/release-cni-plugin.yml
+++ b/.github/workflows/release-cni-plugin.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   meta:
     timeout-minutes: 3
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - id: meta
@@ -27,7 +27,7 @@ jobs:
 
   docker-publish:
     needs: meta
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 25
     permissions:
       id-token: write # needed for signing the images with GitHub OIDC token
@@ -77,7 +77,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - if: needs.meta.outputs.mode == 'release'

--- a/.github/workflows/release-proxy-init.yml
+++ b/.github/workflows/release-proxy-init.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   meta:
     timeout-minutes: 3
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/version-mode
@@ -27,7 +27,7 @@ jobs:
 
   docker-publish:
     needs: meta
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     permissions:
       id-token: write # needed for signing the images with GitHub OIDC token
@@ -77,7 +77,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - if: needs.meta.outputs.mode == 'release'

--- a/.github/workflows/release-validator.yml
+++ b/.github/workflows/release-validator.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   meta:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ghcr.io/linkerd/dev:v44-rust
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -33,7 +33,7 @@ jobs:
       matrix:
         arch: [amd64, arm64, arm]
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ghcr.io/linkerd/dev:v44-rust-musl
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   check:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ghcr.io/linkerd/dev:v44-rust
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -25,7 +25,7 @@ jobs:
 
   audit:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         checks:

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   sh-lint:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: linkerd/dev/actions/setup-tools@v45
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
The test was failing with:

```
  cargo:warning=Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `clang-19` installed?
```

Using linkerd/dev/actions/setup-rust ensures the proper dependencies are set up.

Also, pinned to ubuntu-22.04 for now as ubuntu-latest is lacking everything this build requires.