### PR TITLE
fix(linkerd-cni): fix cleanup logic

### DIFF
--- a/cni-plugin/deployment/scripts/install-cni.sh
+++ b/cni-plugin/deployment/scripts/install-cni.sh
@@ -66,10 +66,13 @@ SERVICEACCOUNT_PATH=/var/run/secrets/kubernetes.io/serviceaccount
 # *conflist files, then linkerd-cni configuration parameters will be removed
 # from them.
 cleanup() {
-  # First, kill 'inotifywait' so we don't process any DELETE/CREATE events
-  if [ "$(pgrep inotifywait)" ]; then
-    log 'Sending SIGKILL to inotifywait'
-    kill -s KILL "$(pgrep inotifywait)"
+  # First, kill both 'inotifywait' processes so we don't process any DELETE/CREATE events
+  pids=$(pgrep inotifywait)
+  if [ -n "$pids" ]; then
+    while read -r pid; do
+      log "Sending SIGKILL to inotifywait (PID: $pid)"
+      kill -s KILL "$pid"
+    done <<< "$pids"
   fi
 
   log 'Removing linkerd-cni artifacts.'


### PR DESCRIPTION
Fixes linkerd/linkerd2#12573

In #440 we introduced an inotifywait call to detect changes in the service account token, to be run in parallel to the existing inotifywait tracking cni config file changes. The cleanup() function didn't account for the additional inotifywait background process, so the call `kill -s
  KILL "$(pgrep inotifywait)"` errored out as it was expecting just one
  PID.

An improper cleanup leaves the linkerd-cni binary deployed in the node, along with its config in the cni config file, so it continues to be called even if the linkerd-cni pod is deleted. The problem is that as soon as the pod is deleted, the service account token that the linkerd-cni binary relies on is revoked, causing the linkerd-cni invocation triggered upon each pod creation in the node to fail with an Unauthorized error. When rolling out the linkerd-cni pod this will happen sometimes, if k8s revokes that token fast enough, blocking any further creation of pods in that node.