### PR TITLE
fix(cni-plugin): append inbound skip ports instead of replacing

### DIFF
--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -247,7 +247,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 			if inboundSkipOverride != "" {
 				logEntry.Debugf("linkerd-cni: overriding InboundPortsToIgnore to %s", inboundSkipOverride)
-				options.InboundPortsToIgnore = strings.Split(inboundSkipOverride, ",")
+				options.InboundPortsToIgnore = append(options.InboundPortsToIgnore, strings.Split(inboundSkipOverride, ",")...)
 			}
 
 			// Check if there are any subnets to skip

--- a/cni-repair-controller/integration/run.sh
+++ b/cni-repair-controller/integration/run.sh
@@ -25,6 +25,9 @@ kubectl apply -f https://k3d.io/v5.1.0/usage/advanced/calico.yaml
 kubectl	--namespace=kube-system wait --for=condition=available --timeout=120s \
   deploy/calico-kube-controllers
 
+# Install gateway API
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/experimental-install.yaml
+
 step 'Installing latest linkerd edge'
 scurl https://run.linkerd.io/install-edge | sh
 export PATH=$PATH:$HOME/.linkerd2/bin


### PR DESCRIPTION
Fixes https://github.com/linkerd/linkerd2/issues/13976

When the Linkerd CNI-plugin acts on a pod with a `config.linkerd.io/skip-inbound-ports` annotation, it replaces the inbound skip ports that the CNI-plugin was configured with instead of adding to them.  The CNI-plugin is configured with the Linkerd proxy's admin and tap ports as skip inbound ports.  Therefore, on any pod with the `config.linkerd.io/skip-inbound-ports` annotation, the admin and tap ports will no longer be skipped by the iptables redirect rules, making these proxy ports inaccessible and causing tap and promethus scraping to no longer function.

Instead of replacing, we append the ports specified in `config.linkerd.io/skip-inbound-ports` to the inbound skip ports.  This allows the admin and tap ports to continue to skip iptables redirection and reach the proxy as desired.

This matches the behavior of the linkerd-init container: https://github.com/linkerd/linkerd2/blob/main/charts/partials/templates/_proxy-init.tpl#L25

Tested manually on k3d with Calico and validating that tap works as expected on workloads with `config.linkerd.io/skip-inbound-ports` configured.  Due to the architecture of the cni-plugin executable, it is not well set up to be tested automatically without further refactoring so we omit automated tests here.