### PR TITLE
chore(validator): enable signal handling for Windows

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -83,7 +83,6 @@ async fn main() {
         }
 
         // If the process is terminated by a signal, exit with an error.
-        // Signal handling
         _ = handle_signals() => {
             exit(UNSUCCESSFUL_EXIT_CODE);
         }


### PR DESCRIPTION
This change modifies the signal handling in the network validator in order to enable it to run on Windows

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>