### PR TITLE
fix(cli): enable help output by explicitly enabling clap's help feature

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -16,7 +16,7 @@ tracing = "0.1"
 [dependencies.clap]
 version = "4"
 default-features = false
-features = ["derive", "env", "std"]
+features = ["derive", "env", "std", "help"]
 
 [dependencies.tokio]
 version = "1"


### PR DESCRIPTION
- In clap v4, the feature system was restructured to be fully granular
- With `default-features = false`, **no features** are enabled, including help
- Previously in v3, help output was always included by default
- Without explicitly enabling the `help` feature, running: `./linkerd-network-validator --help` results in: `error: unexpected argument found`
- This commit adds the `help` feature back to enable standard CLI help text

Ref: https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#400---2022-09-28