### PR TITLE
test(repair-controller): remove unneeded step

### DIFF
--- a/.github/workflows/cni-plugin-integration.yml
+++ b/.github/workflows/cni-plugin-integration.yml
@@ -40,7 +40,6 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-22.04
     steps:
-      - uses: linkerd/dev/actions/setup-rust@v46
       - uses: linkerd/dev/actions/setup-tools@v46
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run repair-controller tests

--- a/justfile
+++ b/justfile
@@ -85,7 +85,7 @@ cni-repair-controller *args:
 # The K3S_IMAGES_JSON file used instructs the creation of a cluster on version
 # v1.27.6-k3s1, because after that Calico won't work.
 # See https://github.com/k3d-io/k3d/issues/1375
-cni-repair-controller-integration $K3S_IMAGES_JSON='./cni-plugin/integration/calico-k3s-images.json': (cni-repair-controller "package") build-cni-plugin-image
+cni-repair-controller-integration $K3S_IMAGES_JSON='./cni-plugin/integration/calico-k3s-images.json': build-cni-plugin-image
     @{{ just_executable() }} K3D_CREATE_FLAGS='{{ _K3D_CREATE_FLAGS_NO_CNI }}' _k3d-cni-create
     @just-k3d use
     @just-k3d import {{ cni-plugin-image }}


### PR DESCRIPTION
The `repair-controller` step in CI is building the cni-repair-controller separately, but that's not used directly. It is built as part of the cni-plugin image.