### PR TITLE
feat!(ci): Remove arm/v7 support

### DIFF
--- a/.github/workflows/release-proxy-init.yml
+++ b/.github/workflows/release-proxy-init.yml
@@ -47,7 +47,7 @@ jobs:
                 build-proxy-init-image \
                   --cache-from type=local,src="$RUNNER_TEMP/.buildx-cache" \
                   --cache-to type=local,dest="$RUNNER_TEMP/.buildx-cache",mode=max \
-                  --platform linux/amd64,linux/arm64,linux/arm/v7
+                  --platform linux/amd64,linux/arm64
       - run: just-dev prune-action-cache "$RUNNER_TEMP/.buildx-cache"
 
       # Only publish images on release
@@ -63,7 +63,7 @@ jobs:
                 build-proxy-init-image \
                   --cache-from type=local,src="$RUNNER_TEMP/.buildx-cache" \
                   --cache-to type=local,dest="$RUNNER_TEMP/.buildx-cache",mode=max \
-                  --platform linux/amd64,linux/arm64,linux/arm/v7 \
+                  --platform linux/amd64,linux/arm64 \
                   --output type=registry
       - if: needs.meta.outputs.mode == 'release'
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159

--- a/.github/workflows/release-validator.yml
+++ b/.github/workflows/release-validator.yml
@@ -31,13 +31,11 @@ jobs:
     needs: meta
     strategy:
       matrix:
-        arch: [amd64, arm64, arm]
+        arch: [amd64, arm64]
         os: [windows, linux]
         exclude:
           - os: windows
             arch: arm64
-          - os: windows
-            arch: arm  
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     container: ghcr.io/linkerd/dev:v47-rust-musl

--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,6 @@
 targets = [
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "aarch64-unknown-linux-gnu" },
-    { triple = "armv7-unknown-linux-gnu" },
 ]
 
 [advisories]

--- a/justfile-rust
+++ b/justfile-rust
@@ -13,7 +13,7 @@ version := `just-cargo crate-version $TARGETCRATE`
 
 profile := 'debug'
 
-# The architecture name to use for packages. Either 'amd64', 'arm64', or 'arm'.
+# The architecture name to use for packages. Either 'amd64' or 'arm64'.
 arch := env_var_or_default("TARGETARCH", "amd64")
 
 # The OS name to use for packages. Either 'linux' or 'windows'.
@@ -25,8 +25,6 @@ _cargo-target := if os + '-' + arch == "linux-amd64" {
         "x86_64-unknown-linux-musl"
     } else if os + '-' + arch == "linux-arm64" {
         "aarch64-unknown-linux-musl"
-    } else if os + '-' + arch == "linux-arm" {
-        "armv7-unknown-linux-musleabihf"
     } else if os + '-' + arch == "windows-amd64" {
         "x86_64-pc-windows-gnu"
     } else {


### PR DESCRIPTION
This architecture has become too significant of a maintenance burden, and isn't used often enough to justify the associated maintenance cost.

This removes arm/v7 from all the build infrastructure/dockerfiles/etc. Note that arm64 targets are still widely used and well supported.

Related: https://github.com/linkerd/linkerd2/pull/14308