### PR TITLE
fix(cni-plugin): remove square brackets from host which may not be ipv6 in kubeconfig

### DIFF
--- a/cni-plugin/deployment/scripts/install-cni.sh
+++ b/cni-plugin/deployment/scripts/install-cni.sh
@@ -157,7 +157,7 @@ kind: Config
 clusters:
 - name: local
   cluster:
-    server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}
+    server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}
     ${TLS_CFG}
 users:
 - name: linkerd-cni


### PR DESCRIPTION
When the install-cni script generates a kubeconfig for the cni-plugin, it wraps the kubernetes service host in square brackets.  This is not valid if the host is an ipv4 address and, as of recent versions of Go, such hosts will fail to be parsed by the `net/url` package.  See: https://github.com/golang/go/commit/d6d2f7bf76718f1db05461cd912ae5e30d7b77ea

Remove the square brackets so that this host can be parsed properly.