### PR TITLE
add proxyInit dual-stack conditional

### DIFF
--- a/proxy-init/cmd/root.go
+++ b/proxy-init/cmd/root.go
@@ -195,9 +195,14 @@ func BuildFirewallConfiguration(options *RootOptions) (*iptables.FirewallConfigu
 	sanitizedSubnets := []string{}
 	for _, subnet := range options.SubnetsToIgnore {
 		subnet := strings.TrimSpace(subnet)
-		_, _, err := net.ParseCIDR(subnet)
+		_, cidr, err := net.ParseCIDR(subnet)
 		if err != nil {
 			return nil, fmt.Errorf("%s is not a valid CIDR address", subnet)
+		}
+
+		isIPv6Subnet := cidr.IP.To4() == nil
+		if isIPv6Subnet != options.IPv6 {
+			continue
 		}
 
 		sanitizedSubnets = append(sanitizedSubnets, subnet)

--- a/proxy-init/cmd/root_test.go
+++ b/proxy-init/cmd/root_test.go
@@ -122,4 +122,62 @@ func TestBuildFirewallConfiguration(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("It filters subnets by address family for dual-stack", func(t *testing.T) {
+		mixedSubnets := []string{"172.16.0.0/12", "fd00::/8", "10.0.0.0/8", "2001:db8::/32"}
+
+		// IPv4 pass (IPv6=false) should only include IPv4 subnets
+		optIPv4 := &RootOptions{
+			IncomingProxyPort: 1234,
+			OutgoingProxyPort: 2345,
+			SubnetsToIgnore:   mixedSubnets,
+			IPTablesMode:      IPTablesModeLegacy,
+			IPv6:              false,
+		}
+		config, err := BuildFirewallConfiguration(optIPv4)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		expectedIPv4 := []string{"172.16.0.0/12", "10.0.0.0/8"}
+		if !reflect.DeepEqual(config.SubnetsToIgnore, expectedIPv4) {
+			t.Fatalf("Expected IPv4 subnets %v but got %v", expectedIPv4, config.SubnetsToIgnore)
+		}
+
+		// IPv6 pass (IPv6=true) should only include IPv6 subnets
+		optIPv6 := &RootOptions{
+			IncomingProxyPort: 1234,
+			OutgoingProxyPort: 2345,
+			SubnetsToIgnore:   mixedSubnets,
+			IPTablesMode:      IPTablesModeLegacy,
+			IPv6:              true,
+		}
+		config, err = BuildFirewallConfiguration(optIPv6)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		expectedIPv6 := []string{"fd00::/8", "2001:db8::/32"}
+		if !reflect.DeepEqual(config.SubnetsToIgnore, expectedIPv6) {
+			t.Fatalf("Expected IPv6 subnets %v but got %v", expectedIPv6, config.SubnetsToIgnore)
+		}
+	})
+
+	t.Run("It handles IPv4-only subnets with dual-stack enabled", func(t *testing.T) {
+		ipv4Only := []string{"172.16.0.0/12"}
+
+		// IPv6 pass should produce empty subnets, not error
+		opt := &RootOptions{
+			IncomingProxyPort: 1234,
+			OutgoingProxyPort: 2345,
+			SubnetsToIgnore:   ipv4Only,
+			IPTablesMode:      IPTablesModeLegacy,
+			IPv6:              true,
+		}
+		config, err := BuildFirewallConfiguration(opt)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if len(config.SubnetsToIgnore) != 0 {
+			t.Fatalf("Expected empty subnets for IPv6 pass with IPv4-only input, got %v", config.SubnetsToIgnore)
+		}
+	})
 }


### PR DESCRIPTION
when running Linkerd in dual stack mode today, skipSubnets breaks proxyInit with error similar to:
```
time="2026-03-18T00:21:37Z" level=info msg="/usr/sbin/ip6tables-nft -t nat -A PROXY_INIT_REDIRECT -p all -j RETURN -s <ipv4-cidr-here> -m comment --comment proxy-init/ignore-subnet-<ipv4-cidr-here>"
time="2026-03-18T00:21:37Z" level=info msg="ip6tables v1.8.11 (nf_tables): host/network `<ipv4-cidr-here>' not found\nTry `ip6tables -h' or 'ip6tables --help' for more information.\n"
```

this breaks when passing either ipv4 or ipv6 subnets to skip subnets (or both), where either the iptables-nft or ip6tables-nft command breaks with the wrong subnet. This PR adds a conditional to verify subnet parsing with the right scheme so that on each invocation only the right subnets are parsed