### PR TITLE
Revert "build(deps): bump golang from 1.25.9-alpine to 1.26.2-alpine in /proxy-init/integration/iptables"

### DIFF
--- a/proxy-init/integration/iptables/Dockerfile-tester
+++ b/proxy-init/integration/iptables/Dockerfile-tester
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine
+FROM golang:1.25.9-alpine
 ENV GOCACHE=/tmp/
 WORKDIR /src
 COPY go.mod go.sum .


### PR DESCRIPTION
Reverts linkerd/linkerd2-proxy-init#719