### PR TITLE
CNI Plugin Integration Test

### DIFF
--- a/cni-plugin/integration/manifests/calico/setup.sh
+++ b/cni-plugin/integration/manifests/calico/setup.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 # setup.sh - Setup a calico cluster as per the instructions:
 # https://k3d.io/v5.8.3/usage/advanced/calico/#1-create-the-cluster-without-flannel
 #

--- a/cni-plugin/integration/manifests/calico/setup.sh
+++ b/cni-plugin/integration/manifests/calico/setup.sh
@@ -1,4 +1,4 @@
-# _setup.sh - Setup a calico cluster as per the instructions:
+# setup.sh - Setup a calico cluster as per the instructions:
 # https://k3d.io/v5.8.3/usage/advanced/calico/#1-create-the-cluster-without-flannel
 #
 # 1. ensure the kube config current context is set

--- a/cni-plugin/integration/manifests/calico/setup.sh
+++ b/cni-plugin/integration/manifests/calico/setup.sh
@@ -1,0 +1,37 @@
+# _setup.sh - Setup a calico cluster as per the instructions:
+# https://k3d.io/v5.8.3/usage/advanced/calico/#1-create-the-cluster-without-flannel
+#
+# 1. ensure the kube config current context is set
+# 2. install the calico tigera operator + poll/wait for deployment
+# 3. install calico CRDs + poll/wait for availability
+# 4. poll/wait for calico kube controllers and node rollout
+printf '# calico/setup.sh\n'
+
+kube_ctx=$(kubectl config current-context 2>/dev/null)
+if [ -z "${kube_ctx}" ];
+then
+    printf "${BASH_SOURCE[0]} requires current context be set\n"
+    exit 1
+fi
+
+kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.0/manifests/tigera-operator.yaml
+kubectl --namespace tigera-operator rollout status --timeout=5m deploy/tigera-operator
+
+until kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.0/manifests/custom-resources.yaml 1>/dev/null 2>&1; do
+    echo "retrying calico custom resources installation..."
+    sleep 2
+done
+for resource in apiserver calico goldmane ippools whisker; do
+    until kubectl wait --for=condition=available --timeout=120s tigerastatus "$resource" 1>/dev/null 2>&1; do
+        echo "retrying tigerastatus/$resource availability check..."
+        sleep 2
+    done
+done
+for rollout in deployment/calico-kube-controllers daemonset/calico-node;
+do
+    until kubectl rollout status --namespace calico-system --timeout=2m "${rollout}" 1>/dev/null 2>&1;
+    do
+        echo "retry calico-system/${rollout} rollout check..."
+        sleep 2
+    done
+done

--- a/cni-plugin/integration/manifests/calico/setup.sh
+++ b/cni-plugin/integration/manifests/calico/setup.sh
@@ -13,7 +13,7 @@ printf '# calico/setup.sh\n'
 kube_ctx=$(kubectl config current-context 2>/dev/null)
 if [ -z "${kube_ctx}" ];
 then
-    printf "${BASH_SOURCE[0]} requires current context be set\n"
+    printf "%s requires current context be set\n" "${BASH_SOURCE[0]}"
     exit 1
 fi
 

--- a/cni-plugin/integration/run-ordering.sh
+++ b/cni-plugin/integration/run-ordering.sh
@@ -9,20 +9,7 @@ NODE_NAME=l5d-server-extra
 kubectl config use-context "k3d-$K3D_CLUSTER_NAME"
 
 printf '\n# Install calico and linkerd-cni...\n'
-# Install calico per instructions from https://k3d.io/v5.8.3/usage/advanced/calico/#1-create-the-cluster-without-flannel
-kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.0/manifests/tigera-operator.yaml
-kubectl --namespace tigera-operator rollout status --timeout=5m deploy/tigera-operator
-until kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.0/manifests/custom-resources.yaml; do
-  echo "retrying calico custom resources installation..."
-  sleep 5
-done
-for tigerastatus_name in apiserver calico goldmane ippools whisker; do
-  until kubectl wait --for=condition=available --timeout=120s tigerastatus "$tigerastatus_name"; do
-    echo "retrying tigerastatus/$tigerastatus_name availability check..."
-    sleep 5
-  done
-done
-
+manifests/calico/setup.sh
 kubectl apply -f manifests/calico/linkerd-cni.yaml
 
 printf '\n# Label node and then add node selectors to calico and linkerd-cni to run only on the current node...\n'

--- a/cni-plugin/integration/run.sh
+++ b/cni-plugin/integration/run.sh
@@ -7,13 +7,12 @@ cd "${BASH_SOURCE[0]%/*}"
 SCENARIO=${CNI_TEST_SCENARIO:-flannel}
 IPTABLES_MODE=${IPTABLES_MODE:-legacy}
 
-# Run kubectl with the correct context.
+# TEST_CTX must be set in the environment prior to running this script
+kubectl config use-context "${TEST_CTX}"
+
+# Run kubectl
 function k() {
-  if [ -n "${TEST_CTX:-}" ]; then
-    kubectl --context="$TEST_CTX" "$@"
-  else
-    kubectl "$@"
-  fi
+   kubectl "$@"
 }
 
 function create_test_lab() {
@@ -28,6 +27,13 @@ function create_test_lab() {
     do
       envsubst < "$f" | k apply -f -
     done
+    setup_file="./manifests/${SCENARIO}/setup.sh"
+    if [ -x "${setup_file}" ];
+    then
+      # executing the setup file will initialize local kubernetes for the test
+      # run as per the scenario.
+      bash -c "set -euo pipefail; ${setup_file}"
+    fi
 }
 
 function cleanup() {
@@ -68,13 +74,6 @@ if k get ns/cni-plugin-test >/dev/null 2>&1 ; then
 fi
 
 create_test_lab
-
-# If installing Calico, need to wait for it to roll first, otherwise pods will
-# be blocked (e.g pods for linkerd-cni)
-if [ "$SCENARIO" == "calico" ]; then
-  wait_rollout "deploy/calico-kube-controllers" "kube-system" "2m"
-  wait_rollout "daemonset/calico-node" "kube-system" "2m"
-fi
 
 # Wait for linkerd-cni daemonset to complete
 wait_rollout "daemonset/linkerd-cni" "linkerd-cni" "30s"

--- a/cni-plugin/integration/run.sh
+++ b/cni-plugin/integration/run.sh
@@ -32,7 +32,7 @@ function create_test_lab() {
     then
       # executing the setup file will initialize local kubernetes for the test
       # run as per the scenario.
-      bash -c "set -euo pipefail; ${setup_file}"
+      "${setup_file}"
     fi
 }
 

--- a/cni-plugin/integration/run.sh
+++ b/cni-plugin/integration/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
+set -euo pipefail
 
 cd "${BASH_SOURCE[0]%/*}"
 
@@ -56,7 +56,7 @@ function wait_rollout() {
     echo "!! $name didn't rollout properly, printing logs";
     k describe "$name" -n "$ns"|| echo "$name not found"
     k logs "$name" -n "$ns" || echo "logs not found for $name"
-    exit $?
+    exit 1
   fi
 }
 


### PR DESCRIPTION
The integration test script for the cni plugin was incorrectly exiting with status code '0' when calling the `wait_rollout` function.  Fixe `run.sh` to exit when the rollout status fails.

Refactor the calico setup into a setup.sh script for the integration test scenario from run-ordering.sh.

Wait for the calico-kube-controllers as well as the node daemonset in the correct namespace (calico-system) vs (kube-system).