### PR TITLE
fix: clean up malformed CNI error output

### DIFF
--- a/cni-plugin/integration/tests/cilium/cilium_test.go
+++ b/cni-plugin/integration/tests/cilium/cilium_test.go
@@ -21,6 +21,6 @@ func TestMain(m *testing.M) {
 
 func TestLinkerdIsLastCNIPlugin(t *testing.T) {
 	if err := runner.CheckCNIPluginIsLast(); err != nil {
-		t.Fatalf("Unexpected error: %e", err)
+		t.Fatalf("Unexpected error: %s", err)
 	}
 }

--- a/cni-plugin/integration/tests/flannel/flannel_test.go
+++ b/cni-plugin/integration/tests/flannel/flannel_test.go
@@ -21,6 +21,6 @@ func TestMain(m *testing.M) {
 
 func TestLinkerdIsLastCNIPlugin(t *testing.T) {
 	if err := runner.CheckCNIPluginIsLast(); err != nil {
-		t.Fatalf("Unexpected error: %e", err)
+		t.Fatalf("Unexpected error: %s", err)
 	}
 }

--- a/cni-plugin/integration/testutil/test_util.go
+++ b/cni-plugin/integration/testutil/test_util.go
@@ -117,7 +117,7 @@ func checkLinkerdCniConf(plugin map[string]any) error {
 
 	proxyGID := proxyInit.ProxyGID
 	if proxyGID != 2102 {
-		return fmt.Errorf("proxy-gid has wrong value, expected: %v, found: %v", 2102, proxyUID)
+		return fmt.Errorf("proxy-gid has wrong value, expected: %v, found: %v", 2102, proxyGID)
 	}
 
 	simulate := proxyInit.Simulate

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -144,7 +144,7 @@ func parseConfig(stdin []byte) (*PluginConf, error) {
 func cmdAdd(args *skel.CmdArgs) error {
 	conf, err := parseConfig(args.StdinData)
 	if err != nil {
-		logrus.Errorf("error parsing config: %e", err)
+		logrus.WithError(err).Error("error parsing config")
 		return err
 	}
 	configureLoggingLevel(conf.LogLevel)
@@ -165,7 +165,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	args.Args = strings.Replace(args.Args, "K8S_POD_NAMESPACE", "K8sPodNamespace", 1)
 	args.Args = strings.Replace(args.Args, "K8S_POD_NAME", "K8sPodName", 1)
 	if err := types.LoadArgs(args.Args, &k8sArgs); err != nil {
-		logrus.Errorf("error loading args %e", err)
+		logrus.WithError(err).Error("error loading args")
 		return err
 	}
 
@@ -185,19 +185,19 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 		config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(configLoadingRules, configOverrides).ClientConfig()
 		if err != nil {
-			logrus.Errorf("linkerd-cni client err with NewNonInteractiveDeferredLoadingClientConfig: %e", err)
+			logrus.WithError(err).Error("linkerd-cni client err with NewNonInteractiveDeferredLoadingClientConfig")
 			return err
 		}
 
 		client, err := kubernetes.NewForConfig(config)
 		if err != nil {
-			logrus.Errorf("linkerd-cni client err with NewForConfig: %e", err)
+			logrus.WithError(err).Error("linkerd-cni client err with NewForConfig")
 			return err
 		}
 
 		pod, err := client.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
-			logrus.Errorf("linkerd-cni client err in client.Pods().Get(): %e", err)
+			logrus.WithError(err).Error("linkerd-cni client err in client.Pods().Get()")
 			return err
 		}
 

--- a/cni-plugin/main_test.go
+++ b/cni-plugin/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/sirupsen/logrus"
+)
+
+func TestCmdAddLogsParseConfigErrorsClearly(t *testing.T) {
+	logger := logrus.StandardLogger()
+	originalOut := logger.Out
+	originalFormatter := logger.Formatter
+	originalLevel := logger.Level
+
+	var logs bytes.Buffer
+	logger.SetOutput(&logs)
+	logger.SetFormatter(&logrus.TextFormatter{
+		DisableTimestamp: true,
+		DisableQuote:     true,
+	})
+	logger.SetLevel(logrus.DebugLevel)
+
+	defer func() {
+		logger.SetOutput(originalOut)
+		logger.SetFormatter(originalFormatter)
+		logger.SetLevel(originalLevel)
+	}()
+
+	err := cmdAdd(&skel.CmdArgs{StdinData: []byte("{")})
+	if err == nil {
+		t.Fatal("expected cmdAdd to fail for invalid JSON")
+	}
+
+	output := logs.String()
+	if !strings.Contains(output, "msg=error parsing config") {
+		t.Fatalf("expected parse error log, got %q", output)
+	}
+	if !strings.Contains(output, "error=linkerd-cni: failed to parse network configuration: unexpected end of JSON input") {
+		t.Fatalf("expected structured parse error field in log, got %q", output)
+	}
+	if strings.Contains(output, "%!e(") {
+		t.Fatalf("expected formatted error message, got %q", output)
+	}
+}


### PR DESCRIPTION
This fixes a small but real logging bug in `cni-plugin`.

Some CNI error paths use `%e` for `error`, so Go prints `%!e(...)` junk instead of the actual message. That shows up on normal failures like bad CNI JSON, bad kube config, or missing integration mounts. Kinda noisy, and it hides the real problem.

What changed
- switch those log and test format strings to `%v` or `%s`
- add a small regression test for the invalid JSON path
- fix the `proxy-gid` mismatch message in the integration test helper

Repro
1. On `main`, run `go test ./cni-plugin/integration/tests/flannel -run TestLinkerdIsLastCNIPlugin -v`
2. In a plain local env, the expected mount is missing, so the test fails
3. Before this patch the failure contains `%!e(...)`
4. With this patch it prints the real path error

Checks
- `go test ./cni-plugin ./proxy-init/... ./pkg/...`
