### PR TITLE
chore(build): update golang to 1.25.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ##
 
 # Cross compile from native platform to target arch
-FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine as go
+FROM --platform=$BUILDPLATFORM golang:1.25.11-alpine as go
 WORKDIR /build
 COPY --link go.mod go.sum .
 COPY --link ./proxy-init ./proxy-init

--- a/Dockerfile-cni-plugin
+++ b/Dockerfile-cni-plugin
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 # Cross compile from native platform to target arch
-FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine as go
+FROM --platform=$BUILDPLATFORM golang:1.25.11-alpine as go
 WORKDIR /build
 COPY --link go.mod go.sum ./
 COPY --link ./cni-plugin ./cni-plugin

--- a/cni-plugin/integration/Dockerfile-tester
+++ b/cni-plugin/integration/Dockerfile-tester
@@ -8,7 +8,7 @@
 #  1) a specific k3d cluster configured with CNI
 #  2) a test suite (e.g. `flannel.go`) runs with a configured CNI plugin.
 
-FROM golang:1.25.10-alpine as build
+FROM golang:1.25.11-alpine as build
 RUN apk add build-base
 ENV GOCACHE=/tmp/
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/linkerd/linkerd2-proxy-init
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/containernetworking/cni v1.3.0

--- a/proxy-init/integration/iptables/Dockerfile-tester
+++ b/proxy-init/integration/iptables/Dockerfile-tester
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-alpine
+FROM golang:1.25.11-alpine
 ENV GOCACHE=/tmp/
 WORKDIR /src
 COPY go.mod go.sum .


### PR DESCRIPTION
This PR updates golang from 1.25.10 to 1.25.11.

This addresses the following CVEs:
[GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) with alias [CVE-2026-42507](https://www.cve.org/CVERecord?id=CVE-2026-42507) 
[GO-2026-5038](https://pkg.go.dev/vuln/GO-2026-5038) with alias [CVE-2026-42504](https://www.cve.org/CVERecord?id=CVE-2026-42504)
[GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) with alias [CVE-2026-27145](https://www.cve.org/CVERecord?id=CVE-2026-27145)
