### PR TITLE
build(deps): dependabot miss

### DIFF
--- a/cni-plugin/integration/Dockerfile-tester
+++ b/cni-plugin/integration/Dockerfile-tester
@@ -8,7 +8,7 @@
 #  1) a specific k3d cluster configured with CNI
 #  2) a test suite (e.g. `flannel.go`) runs with a configured CNI plugin.
 
-FROM golang:1.25.11-alpine as build
+FROM golang:1.26.4-alpine as build
 RUN apk add build-base
 ENV GOCACHE=/tmp/
 WORKDIR /src


### PR DESCRIPTION
Bump golang version to 1.26.4-alpine in test Dockerfile.
See: #759