### PR TITLE
fix(ci): capture additional '.' in version suffix

### DIFF
--- a/.github/actions/version-mode/action.yml
+++ b/.github/actions/version-mode/action.yml
@@ -18,7 +18,7 @@ runs:
         set -eu
         shopt -s extglob
         ref="${{ github.ref }}"
-        if [[ "$ref" == refs/tags/${{ inputs.package }}/v+([0-9]).+([0-9]).+([0-9])?(-+([a-z0-9-])) ]]; then
+        if [[ "$ref" == refs/tags/${{ inputs.package }}/v+([0-9]).+([0-9]).+([0-9])?(-+([a-z0-9-.])) ]]; then
           ( echo version="${ref##refs/tags/${{ inputs.package }}/}"
             echo mode=release
           ) >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
I tested the change by copying the conditional into a script.

```bash
#!/usr/bin/env bash
set -eu
shopt -s extglob

function match() {
	ref=${1}
	if [[ "$ref" == refs/tags/cni-plugin/v+([0-9]).+([0-9]).+([0-9])?(-+([a-z0-9-.])) ]]; then
		echo " HIT: $ref"
	else
		echo "MISS: $ref"
	fi
}

match "refs/tags/cni-plugin/v1.7.0"
match "refs/tags/cni-plugin/v1.7.0-alpha"
match "refs/tags/cni-plugin/v1.7.0-alpha.1"
match "refs/tags/cni-plugin/v1.7.0-alpha-1"
match "refs/tags/cni-plugin/experimental"
```
```bash
 HIT: refs/tags/cni-plugin/v1.7.0
 HIT: refs/tags/cni-plugin/v1.7.0-alpha
 HIT: refs/tags/cni-plugin/v1.7.0-alpha.1
 HIT: refs/tags/cni-plugin/v1.7.0-alpha-1
MISS: refs/tags/cni-plugin/experimental
```